### PR TITLE
Reduce apc.shm_size to fix apc_mmap error thrown by APCU.

### DIFF
--- a/cli/stubs/z-performance.ini
+++ b/cli/stubs/z-performance.ini
@@ -55,7 +55,7 @@ apc.cache_by_default = false
 
 [apcu]
 apc.enabled=1
-apc.shm_size=2048M
+apc.shm_size=512M
 apc.ttl=7200
 apc.mmap_file_mask=/tmp/apc.XXXXXX
 apc.enable_cli=1


### PR DESCRIPTION
This PR reduces the `apc.shm_size` from 2048MB to 512MB.

Fixes #45 