### PR TITLE
Support both signed and unsigned static assets

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -93,11 +93,15 @@ class Magento2ValetDriver extends ValetDriver
         }
 
         if ($isMagentoStatic) {
-            $resource = preg_replace('#static(/version[0-9]+)?/#', '', $uri, 1);
-            $uri = '/static' . $resource;
+            $resource = preg_replace('#static(/version[0-9]+)?/#', 'static/', $uri, 1);
+            $uri = $resource;
         }
 
-        if (file_exists($staticFilePath = $sitePath . '/pub' . $uri)) {
+        if(strpos($uri, '/pub/') === false){
+            $uri = '/pub' . $uri;
+        }
+
+        if (file_exists($staticFilePath = $sitePath . $uri)) {
             return $staticFilePath;
         }
 


### PR DESCRIPTION
Came across a Magento install that did not have static signing enabled causing all assets on the frontend to 404. I was able to narrow down that it was due to how the URI was being handle in the M2 driver. 