### PR TITLE
Stop and (re)start Dnsmasq service.

### DIFF
--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -138,4 +138,22 @@ class DnsMasq
     {
         return $_SERVER['HOME'].'/.valet/dnsmasq.conf';
     }
+
+    /**
+     * Start the service.
+     *
+     * @return void
+     */
+    function restart() {
+        $this->brew->restartService('dnsmasq');
+    }
+
+    /**
+     * Stop the service.
+     *
+     * @return void
+     */
+    function stop() {
+        $this->brew->stopService('dnsmasq');
+    }
 }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -241,6 +241,7 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('start [services]*', function ($services) {
         if(empty($services)) {
+            DnsMasq::restart();
             PhpFpm::restart();
             Nginx::restart();
             Mysql::restart();
@@ -289,6 +290,7 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('restart [services]*', function ($services) {
         if(empty($services)) {
+            DnsMasq::restart();
             PhpFpm::restart();
             Nginx::restart();
             Mysql::restart();
@@ -339,6 +341,7 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('stop [services]*', function ($services) {
         if(empty($services)) {
+            DnsMasq::stop();
             PhpFpm::stop();
             Nginx::stop();
             Mysql::stop();


### PR DESCRIPTION
I'm not sure if stopping and starting Dnsmasq can have any adverse effects? Securing en unsecuring worked fine after stop/starting dnsmasq. But when you stop valet+ you should be able to stop all the services, right?