### PR TITLE
Update n98-magerun2 commands to config:store:set

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -26,14 +26,14 @@ class Magento2ValetDriver extends ValetDriver
         }
 
         info('Setting base url...');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:set web/unsecure/base_url ' . $url . '/');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:set web/secure/base_url ' . $url . '/');
+        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set web/unsecure/base_url ' . $url . '/');
+        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set web/secure/base_url ' . $url . '/');
 
         info('Setting elastic search hostname...');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:set catalog/search/elasticsearch_server_hostname 127.0.0.1');
+        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set catalog/search/elasticsearch_server_hostname 127.0.0.1');
         
         info('Enabling URL rewrites...');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:set web/seo/use_rewrites 1');
+        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set web/seo/use_rewrites 1');
         
         info('Flushing cache...');
         $devtools->cli->quietlyAsUser('n98-magerun2 cache:flush');


### PR DESCRIPTION
The latest version of `n98-magerun2` installed through homebrew no longer has the `config:set` command. 

This pull requests updates the command to the [newer command](https://github.com/netz98/n98-magerun2/tree/2.1.2#set-config) `config:store:set` (as ov version 2.1.2 of n98-magerun2).