### PR TITLE
Fixed valet domain not being set for valet services

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -70,6 +70,8 @@ class Nginx
      */
     function installServer()
     {
+        $domain = $this->configuration->read()['domain'];
+
         $this->files->ensureDirExists('/usr/local/etc/nginx/valet');
 
         $this->files->putAsUser(
@@ -83,12 +85,20 @@ class Nginx
 
         $this->files->putAsUser(
             '/usr/local/etc/nginx/valet/mailhog.conf',
-            $this->files->get(__DIR__.'/../stubs/mailhog.conf')
+            str_replace(
+                ['VALET_DOMAIN'],
+                [$domain],
+                $this->files->get(__DIR__ . '/../stubs/mailhog.conf')
+            )
         );
 
         $this->files->putAsUser(
             '/usr/local/etc/nginx/valet/elasticsearch.conf',
-            $this->files->get(__DIR__.'/../stubs/elasticsearch.conf')
+            str_replace(
+                ['VALET_DOMAIN'],
+                [$domain],
+                $this->files->get(__DIR__ . '/../stubs/mailhog.conf')
+            )
         );
 
         $this->files->putAsUser(

--- a/cli/stubs/elasticsearch.conf
+++ b/cli/stubs/elasticsearch.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name elasticsearch.test www.elasticsearch.test;
+    server_name elasticsearch.VALET_DOMAIN www.elasticsearch.VALET_DOMAIN;
     charset utf-8;
     client_max_body_size 128M;
 

--- a/cli/stubs/mailhog.conf
+++ b/cli/stubs/mailhog.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name mailhog.test www.mailhog.test;
+    server_name mailhog.VALET_DOMAIN www.mailhog.VALET_DOMAIN;
     charset utf-8;
     client_max_body_size 128M;
 


### PR DESCRIPTION
PR for https://github.com/weprovide/valet-plus/issues/115.

Adding the valet domain to mailhog and elasticsearch instead of .test.