### PR TITLE
Fixed error messages being undescriptive in Pecl#replaceIniDefinition()

### DIFF
--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -495,9 +495,8 @@ class Pecl
     private function replaceIniDefinition($extension, $phpIniFile, $result)
     {
         if (!preg_match("/Installing '(.*$extension.so)'/", $result, $matches)) {
-            $error = substr($result, count($result) - 200, count($result));
             throw new DomainException('Could not find installation path for: ' . $extension .
-                "\nCommand: pecl install $extension, failed! Error:\n\n\n $error");
+                "\n\n$result");
         }
 
         if (!preg_match('/(zend_extension|extension)\="(.*' . $extension . '.so)"/', $phpIniFile, $iniMatches)) {


### PR DESCRIPTION
Solves undescriptive error messages.

Before:

![https://i.imgur.com/bmVuoyB.jpg](https://i.imgur.com/bmVuoyB.jpg)

After:

![https://i.imgur.com/MqSLx1k.jpg](https://i.imgur.com/MqSLx1k.jpg)
