### PR TITLE
Fix bug with switching regarding pecl ext_dir and php_ini config

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -255,7 +255,7 @@ class Brew
             throw new DomainException("Unable to determine linked PHP.");
         }
 
-        $resolvedPath = str_replace(["@", "."], "", $this->files->readLink('/usr/local/bin/php'));
+        $resolvedPath = $this->files->readLink('/usr/local/bin/php');
 
         $versions = self::SUPPORTED_PHP_FORMULAE;
 

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -254,7 +254,7 @@ class Brew
         if (!$this->files->isLink('/usr/local/bin/php')) {
             throw new DomainException("Unable to determine linked PHP.");
         }
-	
+
         $resolvedPath = str_replace(["@", "."], "", $this->files->readLink('/usr/local/bin/php'));
 
         $versions = self::SUPPORTED_PHP_FORMULAE;

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -255,7 +255,7 @@ class Brew
             throw new DomainException("Unable to determine linked PHP.");
         }
 	
-	$resolvedPath = str_replace(["@", "."], "", $this->files->readLink('/usr/local/bin/php'));
+        $resolvedPath = str_replace(["@", "."], "", $this->files->readLink('/usr/local/bin/php'));
 
         $versions = self::SUPPORTED_PHP_FORMULAE;
 

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -521,7 +521,7 @@ class Pecl
      * @param $extension
      * @param $phpIniFile
      *
-     * @return bool|null|string|string[]
+     * @return string
      */
     private function createIniDefinition($extension, $phpIniFile)
     {
@@ -545,8 +545,7 @@ class Pecl
                 output('[PECL] ' . $extensionPath . ' doesn\'t exist.');
             }
         }
-
-        return false;
+        return $phpIniFile;
     }
 
     /**

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -512,19 +512,10 @@ class Pecl
             throw new DomainException('Could not find installation path for: ' . $extension .
                 "\n\n$result");
         }
-        $extensionRegex = '/^(zend_extension|extension)\="(.*' . $extension . '.so)"$/ms';
-        $phpIniFile = preg_replace($extensionRegex, '', $phpIniFile);
-        return $this->createIniDefinition($extension, $phpIniFile);
-    }
+        $phpIniFile = preg_replace(
+            '/^(zend_extension|extension)\="(.*' . $extension . '.so)"$/ms', '', $phpIniFile
+        );
 
-    /**
-     * @param $extension
-     * @param $phpIniFile
-     *
-     * @return string
-     */
-    private function createIniDefinition($extension, $phpIniFile)
-    {
         $extensionDir = preg_replace(
             "/(^\/.*)(\/php@\d+\.\d+)\/(.*)/", "$1$2",
             $this->getExtensionDirectory()

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -529,10 +529,9 @@ class Pecl
             "/(^\/.*)(\/php@\d+\.\d+)\/(.*)/", "$1$2",
             $this->getExtensionDirectory()
         );
-        $extensionDir .= '/'.max(scandir($extensionDir)).'/pecl/xxxxx';
-        $extensionPath = trim(str_replace("\n", "", $extensionDir));
-        preg_match("/^.*pecl\//", $extensionPath, $matches);
-        $extensionDirParent = reset($matches);
+        $extensionDir .= '/'.max(scandir($extensionDir)).'/pecl/';
+        $extensionDirParent = trim(str_replace("\n", "", $extensionDir));
+
         $directories = scandir($extensionDirParent);
         foreach ($directories as $possibleMatch) {
             if ($possibleMatch == "." || $possibleMatch == "..") continue;
@@ -540,7 +539,8 @@ class Pecl
             if (file_exists($extensionPath)) {
                 $this->setPeclConfig('ext_dir', $extensionDirParent . $possibleMatch);
                 info('[PECL] Creating ini definition for extension ' . $extensionPath);
-                return "extension=\"".$extensionPath."\"\n".$phpIniFile;
+                return (in_array($extension, ['xdebug', 'ioncube']) ? 'zend_' : '').
+                    "extension=\"".$extensionPath."\"\n".$phpIniFile;
             } else {
                 output('[PECL] ' . $extensionPath . ' doesn\'t exist.');
             }

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -220,9 +220,10 @@ class Pecl
     /**
      * Install a single extension.
      *
-     * @param $extension
-     *    The extension key name.
+     * @param string $extension The extension key name.
      * @param null $version
+     *
+     * @return string
      */
     private function install($extension, $version = null)
     {
@@ -449,9 +450,9 @@ class Pecl
         $alias = $this->getExtensionAlias($extension);
         $phpIniFile = $this->files->get($phpIniPath);
         if ($this->isCustomExtension($extension)) {
-            $phpIniFile = preg_replace('/;?(zend_extension|extension)\=".*' . $alias . '"/', '', $phpIniFile);
+            $phpIniFile = preg_replace('/;?(zend_extension|extension)\=".*' . $alias . '"\n?/', '', $phpIniFile);
         } else {
-            $phpIniFile = preg_replace('/;?(zend_extension|extension)\=".*' . $alias . '.so"/', '', $phpIniFile);
+            $phpIniFile = preg_replace('/;?(zend_extension|extension)\=".*' . $alias . '.so"\n?/', '', $phpIniFile);
         }
         $this->saveIniFile($phpIniPath, $phpIniFile);
     }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -139,7 +139,6 @@ class PhpFpm
         if ($version === $currentVersion) {
             return false;
         }
-
         $this->pecl->uninstallExtensions();
 
         $this->cli->passthru('brew unlink php@' . $currentVersion);
@@ -151,6 +150,11 @@ class PhpFpm
 
         $this->cli->passthru('brew link php@' . $version.' --force --overwrite');
         $this->stop();
+
+        info('Setting pecl config');
+        info($this->pecl->setPeclConfig('php_ini', str_replace($currentVersion, $version, $this->pecl->getPhpIniPath())));
+        info($this->pecl->setPeclConfig('ext_dir', str_replace($currentVersion, $version, $this->pecl->getExtensionDirectory())));
+
         $this->install();
         return true;
     }


### PR DESCRIPTION
- PECL configs php_ini and ext_dir wouldn't switch along with homebrew links
- Created method to automatically detect and add ini definitions