### PR TITLE
set version no. = latest tag

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -21,7 +21,7 @@ use SebastianBergmann\Version;
 Container::setInstance(new Container);
 
 // get current version based on git describe and tags
-$version = new Version('0.0.0' , __DIR__ . '/../');
+$version = new Version('1.0.14' , __DIR__ . '/../');
 
 $app = new Application('Valet+', $version->getVersion());
 


### PR DESCRIPTION
"valet on-latest-version" will never return YES for composer-based installations of Valet+
(because the .git directory will never exist)