### PR TITLE
[cleanup] Duplicate memory limit & Whitespace removed

### DIFF
--- a/cli/stubs/z-performance.ini
+++ b/cli/stubs/z-performance.ini
@@ -21,7 +21,7 @@ suhosin.session.cryptua = off
 zend.enable_gc = off
 
 ; Use mailhog for sending emails
-sendmail_path = /usr/local/bin/MailHog sendmail test@test  
+sendmail_path = /usr/local/bin/MailHog sendmail test@test
 
 [opcache]
 opcache.enable = 1

--- a/cli/stubs/z-performance.ini
+++ b/cli/stubs/z-performance.ini
@@ -5,7 +5,7 @@ date.timezone = "TIMEZONE"
 max_execution_time = 300
 
 ; Max memory per instance
-memory_limit = 128M
+memory_limit = 2G
 
 ;The maximum size of an uploaded file.
 upload_max_filesize = 128M
@@ -16,7 +16,6 @@ post_max_size = 128M
 session.auto_start = off
 session.gc_probability = 0
 suhosin.session.cryptua = off
-memory_limit=2G
 
 ; Disable garbage collector
 zend.enable_gc = off


### PR DESCRIPTION
- removed a duplicate memory_limit setting, now the latter setting is at the top, the latter is removed, as I thought 2G is more logical for composer installs & co in development.
- removed trailings space