### PR TITLE
Allow to have an stores.json file in the project to easily setup multiple storeviews

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -169,8 +169,27 @@ class Magento2ValetDriver extends ValetDriver
             exit;
         }
 
+        if (file_exists($sitePath . '/stores.json')) {
+            $this->parseStoresConfig(file_get_contents($sitePath . '/stores.json'), $siteName);
+        }
+
         $_SERVER['DOCUMENT_ROOT'] = $sitePath;
 
         return $sitePath . '/pub/index.php';
+    }
+
+    private function parseStoresConfig($json, $siteName)
+    {
+        $stores = json_decode($json, JSON_OBJECT_AS_ARRAY);
+
+        if (json_last_error() !== JSON_ERROR_NONE || empty($stores)) {
+            return;
+        }
+
+        if (!array_key_exists($siteName, $stores)) {
+            return;
+        }
+
+        $_SERVER = array_merge($_SERVER, $stores[$siteName]);
     }
 }


### PR DESCRIPTION
So when working with Magento 2 it is possible to have multiple website on the same installation, eg website1.test and website2.test points to the same installation but serve a different settings/theme/website based on the settings. Magento 2 uses server variables set normally by the server.

As Valet+ uses PHP for this, i have added an option to have an `stores.json` file in the project. This allows to set the correct variables based on the configuration and current website. This requires the file to be in this format:

```
{
  "website1": {
    "MAGE_RUN_CODE": "storeviewcode"
  },
  "website2": {
    ...
  }
}
```

If a website is matched by the `$siteName`, then all variables are injected in the global `$_SERVER` variable.

At this moment the recommended way according to #77 is to create a custom frontend driver that extends the `Magento2Driver`. With this pull request all you have to do is to create an `stores.json` according to the format.

I would like to document this feature, but i'm not sure where to place it. Any recommendations?