### PR TITLE
Introduce PECL enabled states

### DIFF
--- a/cli/Valet/AbstractPecl.php
+++ b/cli/Valet/AbstractPecl.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Valet;
+
+use Exception;
+use DomainException;
+
+abstract class AbstractPecl
+{
+    // Extension types.
+    const NORMAL_EXTENSION_TYPE = 'extension';
+    const ZEND_EXTENSION_TYPE = 'zend_extension';
+
+    /**
+     * Shared functionality example:
+     *
+     * Shared functionality can be used for both custom and PECL managed .so files. For example the 'default' key
+     * allows one to disable the module by default. This is useful for modules that enable through on/off commands,
+     * like ioncube and xdebug.
+     *
+     * @formatter:off
+     *
+     * 'extension_key_name' => [
+     *    'default' => false
+     * ]
+     *
+     * @formatter:on
+     **/
+    const EXTENSIONS = [
+
+    ];
+
+    var $cli, $files;
+
+    /**
+     * Create a new PECL instance.
+     */
+    function __construct(CommandLine $cli, Filesystem $files)
+    {
+        $this->cli = $cli;
+        $this->files = $files;
+    }
+
+    /**
+     * Get the extension type: zend_extension or extension for the custom extension.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return mixed
+     */
+    protected function getExtensionType($extension)
+    {
+        if (array_key_exists('extension_type', $this::EXTENSIONS[$extension])) {
+            return $this::EXTENSIONS[$extension]['extension_type'];
+        }
+        throw new DomainException('extension_type key is required for PECL packages');
+    }
+
+    /**
+     * Get the php.ini file path from the PECL config.
+     *
+     * @return mixed
+     */
+    public function getPhpIniPath()
+    {
+        return str_replace("\n", '', $this->cli->runAsUser('pecl config-get php_ini'));
+    }
+
+    /**
+     * Get the current PHP version from the PECL config.
+     *
+     * @return string
+     *    The php version as string: 5.6, 7.0, 7.1, 7.2
+     */
+    protected function getPhpVersion()
+    {
+        $version = $this->cli->runAsUser('pecl version | grep PHP');
+        $version = str_replace('PHP Version:', '', $version);
+        $version = str_replace(' ', '', $version);
+        $version = substr($version, 0, 3);
+        return $version;
+    }
+
+    /**
+     * Check if the extension is enabled within the php installation.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return bool
+     *   True if installed, false if not installed.
+     */
+    public function isEnabled($extension)
+    {
+        $alias = $this->getExtensionAlias($extension);
+        $extensions = explode("\n", $this->cli->runAsUser("php -m | grep $alias"));
+        return in_array($alias, $extensions);
+    }
+
+    /**
+     * Get the extension directory from the PECL config.
+     *
+     * @return mixed
+     */
+    public function getExtensionDirectory()
+    {
+        return str_replace("\n", '', $this->cli->runAsUser('pecl config-get ext_dir'));
+    }
+
+    /**
+     * Uninstall all extensions defined in EXTENSIONS.
+     */
+    function uninstallExtensions()
+    {
+        throw new \Exception(__METHOD__.' not implemented!');
+    }
+
+    /**
+     * Install all extensions defined in EXTENSIONS.
+     *
+     * @param bool $onlyDefaults
+     * @throws Exception if not overridden but used.
+     */
+    public function installExtensions($onlyDefaults = true){
+        throw new \Exception(__METHOD__.' not implemented!');
+    }
+
+    /**
+     * Check if the extension is installed.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return bool True if installed, false if not installed.
+     * True if installed, false if not installed.
+     * @throws Exception if not overridden but used.
+     */
+    protected function isInstalled($extension)
+    {
+        throw new \Exception(__METHOD__.' not implemented!');
+    }
+
+    /**
+     * Get the extension alias for the extension. Should return the alias of the .so file without the .so extension.
+     * E.G: apcu, apc, xdebug, geoip, etc...
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return string
+     * @throws Exception if not overridden but used.
+     */
+    protected function getExtensionAlias($extension)
+    {
+        throw new \Exception(__METHOD__.' not implemented!');
+    }
+}

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -304,6 +304,136 @@ class Pecl extends AbstractPecl
     }
 
     /**
+     * Fix common problems related to the PECL/PEAR installation.
+     */
+    function fix(){
+        info('[PECL] Checking pear config...');
+        // Check if pear config is set correctly as per:
+        // https://github.com/kabel/homebrew-core/blob/2564749d8f73e43cbb8cfc449bca4f564ac0e9e1/Formula/php%405.6.rb
+        // Brew installation standard.
+        foreach (['5.6', '7.0', '7.1', '7.2'] as $phpVersion){
+            output("Checking php $phpVersion...");
+
+            $pearConfigPath = "/usr/local/etc/php/$phpVersion/pear.conf";
+
+            if(!$this->files->exists($pearConfigPath)){
+                warning("    Skipping $phpVersion, Pear config path could not be found at: $pearConfigPath");
+                continue;
+            }
+
+            $pearConfig = $this->files->get($pearConfigPath);
+            $pearConfigSplit = explode("\n", $pearConfig);
+
+            $pearConfigVersion = '';
+            $pearConfig = false;
+            foreach($pearConfigSplit as $splitValue){
+                if(strpos($splitValue, 'php_ini')){
+                    $pearConfig = unserialize($splitValue);
+                }else if(strpos($splitValue, 'Config')){
+                    $pearConfigVersion = $splitValue;
+                }else{
+                    continue;
+                }
+            }
+
+            if($pearConfig === false){
+                warning("Could not determine pear configuration for PhP version: $phpVersion, skipping...");
+                continue;
+            }
+
+            $phpIniPath = str_replace('pear.conf', 'php.ini', $pearConfigPath);
+            $phpDirPath = "/usr/local/share/pear@$phpVersion";
+            $pearDocDirPath = "/usr/local/share/pear@$phpVersion/doc";
+            $phpExtensionDirPath = '/usr/local/lib/php/pecl/'.basename($pearConfig['ext_dir']);
+            $phpBinPath = "/usr/local/opt/php@$phpVersion/bin";
+            $pearDataDirPath = "/usr/local/share/pear@$phpVersion/data";
+            $pearCfgDirPath = "/usr/local/share/pear@$phpVersion/cfg";
+            $pearWwwDirPath = "/usr/local/share/pear@$phpVersion/htdocs";
+            $pearManDirPath = '/usr/local/share/man';
+            $pearTestDirPath = "/usr/local/share/pear@$phpVersion/test";
+            $phpBinDirPath = "/usr/local/opt/php@$phpVersion/bin/php";
+
+            // PhP 7.2 doesn't work with a @ version annotation.
+            if($phpVersion === '7.2'){
+                $phpDirPath = str_replace("@$phpVersion", '', $phpDirPath);
+                $pearDocDirPath = str_replace("@$phpVersion", '', $pearDocDirPath);
+                $phpBinPath = str_replace("@$phpVersion", '', $phpBinPath);
+                $pearDataDirPath = str_replace("@$phpVersion", '', $pearDataDirPath);
+                $pearCfgDirPath = str_replace("@$phpVersion", '', $pearCfgDirPath);
+                $pearWwwDirPath = str_replace("@$phpVersion", '', $pearWwwDirPath);
+                $pearDataDirPath = str_replace("@$phpVersion", '', $pearDataDirPath);
+                $pearTestDirPath = str_replace("@$phpVersion", '', $pearTestDirPath);
+                $phpBinDirPath = str_replace("@$phpVersion", '', $phpBinDirPath);
+            }
+
+            // Check php_ini value of par config.
+            if(empty($pearConfig['php_ini']) || $pearConfig['php_ini'] !== $phpIniPath){
+                output("    Setting pear config php_ini directive to: $phpIniPath");
+                $pearConfig['php_ini'] = $phpIniPath;
+            }
+            // Check php_dir value of par config.
+            if(empty($pearConfig['php_dir']) || $pearConfig['php_dir'] !== $phpDirPath){
+                output("    Setting pear config php_dir directive to: $phpDirPath");
+                $pearConfig['php_dir'] = $phpDirPath;
+            }
+            // Check doc_dir value of par config.
+            if(empty($pearConfig['doc_dir']) || $pearConfig['doc_dir'] !== $pearDocDirPath){
+                output("    Setting pear config doc_dir directive to: $pearDocDirPath");
+                $pearConfig['doc_dir'] = $pearDocDirPath;
+            }
+            // Check ext_dir value of par config.
+            if(empty($pearConfig['ext_dir']) || $pearConfig['ext_dir'] !== $phpExtensionDirPath){
+                output("    Setting pear config ext_dir directive to: $phpExtensionDirPath");
+                $pearConfig['ext_dir'] = $phpExtensionDirPath;
+            }
+            // Check php_bin value of par config.
+            if(empty($pearConfig['bin_dir']) || $pearConfig['bin_dir'] !== $phpBinPath){
+                output("    Setting pear config bin_dir directive to: $phpBinPath");
+                $pearConfig['bin_dir'] = $phpBinPath;
+            }
+            // Check data_dir value of par config.
+            if(empty($pearConfig['data_dir']) || $pearConfig['data_dir'] !== $pearDataDirPath){
+                output("    Setting pear config data_dir directive to: $pearDataDirPath");
+                $pearConfig['data_dir'] = $pearDataDirPath;
+            }
+            // Check cfg_dir value of par config.
+            if(empty($pearConfig['cfg_dir']) || $pearConfig['cfg_dir'] !== $pearCfgDirPath){
+                output("    Setting pear config cfg_dir directive to: $pearCfgDirPath");
+                $pearConfig['cfg_dir'] = $pearCfgDirPath;
+            }
+            // Check www_dir value of par config.
+            if(empty($pearConfig['www_dir']) || $pearConfig['www_dir'] !== $pearWwwDirPath){
+                output("    Setting pear config www_dir directive to: $pearWwwDirPath");
+                $pearConfig['www_dir'] = $pearWwwDirPath;
+            }
+            // Check man_dir value of par config.
+            if(empty($pearConfig['man_dir']) || $pearConfig['man_dir'] !== $pearManDirPath){
+                output("    Setting pear config man_dir directive to: $pearManDirPath");
+                $pearConfig['man_dir'] = $pearManDirPath;
+            }
+            // Check test_dir value of par config.
+            if(empty($pearConfig['test_dir']) || $pearConfig['test_dir'] !== $pearTestDirPath){
+                output("    Setting pear config test_dir directive to: $pearTestDirPath");
+                $pearConfig['test_dir'] = $pearTestDirPath;
+            }
+            // Check php_bin value of par config.
+            if(empty($pearConfig['php_bin']) || $pearConfig['php_bin'] !== $phpBinDirPath){
+                output("    Setting pear config php_bin directive to: $phpBinDirPath");
+                $pearConfig['php_bin'] = $phpBinDirPath;
+            }
+
+            // Rebuild the config.
+            $pearConfig = serialize($pearConfig);
+            if(!empty($pearConfigVersion)){
+                $pearConfig = $pearConfigVersion."\n".$pearConfig;
+            }
+
+            // Put config back into the pear.conf file.
+            $this->files->put($pearConfigPath, $pearConfig);
+        }
+    }
+
+    /**
      * @inheritdoc
      */
     function isInstalled($extension)

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -5,7 +5,7 @@ namespace Valet;
 use Exception;
 use DomainException;
 
-class Pecl
+class Pecl extends AbstractPecl
 {
 
     // Extensions.
@@ -13,79 +13,27 @@ class Pecl
     const APCU_EXTENSION = 'apcu';
     const APCU_BC_EXTENSION = 'apcu_bc';
     const GEOIP_EXTENSION = 'geoip';
-    const IONCUBE_LOADER_EXTENSION = 'ioncube_loader_dar';
-
-    // File extensions.
-    const TAR_GZ_FILE_EXTENSION = '.tar.gz';
 
     // Extension aliases.
     const APCU_BC_ALIAS = 'apc';
 
-    // Extension types.
-    const NORMAL_EXTENSION_TYPE = 'extension';
-    const ZEND_EXTENSION_TYPE = 'zend_extension';
-
     /**
-     * Supported pecl extensions for the pecl manager. There are 2 types of extensions supported: zend_extensions and
-     * extensions. Not all extension are available through PECL. Therefore there are also 2 installation methods: pecl
-     * and custom.
+     * Supported pecl extensions for the PECL manager. There are 2 types of extensions supported: zend_extensions and
+     * extensions. Not all extension are available through PECL. This class handles packages that are handled by PECL.
      *
      * PECL example:
      *
-     * The PECL extensions sometimes differ in version per PHP version. For example xDebug can only be installed on
+     * The PECL extensions sometimes differ in version per PHP version. For example Xdebug can only be installed on
      * PHP 5.6 using the 2.2.7 version. In such a case one would define the version within the array as key. The value
-     * would be 2.2.7 which is the version to be installed. See example below:
+     * would be 2.2.7 which is the version to be installed. See example below.
+     *
+     * The 'default' key allows one to disable the module by default. This is useful for modules that enable through
+     * on/off commands, like Xdebug.
      *
      * @formatter:off
      *
      * 'extension_key_name' => [
      *    '5.6' => '2.2.7'
-     * ]
-     *
-     * @formatter:on
-     *
-     * CUSTOM example:
-     *
-     * Packages that are not available through PECL can be downloaded using the custom method. One needs to define the
-     * 'custom' key with value true so the manager knows this package is custom and needs to be downloaded. Then every
-     * PHP version requires a download link so the manager can download the .so file for the active PHP version.
-     *
-     * .so files can be packages by different file extensions. Use the file_extension key to set the file extension
-     * of the downloaded file.
-     *
-     * Because packages files can contain a directory with a different name the manager will be unable to find the
-     * unpackages folder. Set packaged_directory so that it equals the folder name after unpackaging the folder.
-     *
-     * Downloaded extensions can either be of type zend_extension or extension. Because the manager does not know
-     * what kind of extension the downloaded.so file is one defines extension_type with one of the extension types.
-     *
-     * To check if the extension is active the manager uses extension_php_name. The manager check of php -m returns the
-     * extension name.
-     *
-     * @formatter:off
-     *
-     * 'extension_key_name' => [
-     *    '7.2' => 'https://example.com/packagename.extension',
-     *    '7.1' => 'https://example.com/packagename.extension',
-     *    '7.0' => 'https://example.com/packagename.extension',
-     *    '5.6' => 'https://example.com/packagename.extension',
-     *    'file_extension' => self::TAR_GZ_FILE_EXTENSION,
-     *    'extension_type' => self::ZEND_EXTENSION_TYPE,
-     *    'extension_php_name' => 'the ionCube PHP Loader',
-     *    'custom' => true
-     * ]
-     *
-     * @formatter:on
-     *
-     * Shared functionality example:
-     *
-     * Shared functionality can be used for both custom and PECL managed .so files. For example the 'default' key
-     * allows one to disable the module by default. This is useful for modules that enable through on/off commands,
-     * like ioncube and xdebug.
-     *
-     * @formatter:off
-     *
-     * 'extension_key_name' => [
      *    'default' => false
      * ]
      *
@@ -94,89 +42,256 @@ class Pecl
     const EXTENSIONS = [
         self::XDEBUG_EXTENSION => [
             '5.6' => '2.2.7',
-            'default' => false
+            'default' => false,
+            'extension_type' => self::ZEND_EXTENSION_TYPE
         ],
         self::APCU_BC_EXTENSION => [
-            '5.6' => false
+            '5.6' => false,
+            'extension_type' => self::NORMAL_EXTENSION_TYPE
         ],
         self::APCU_EXTENSION => [
             '7.2' => false,
             '7.1' => false,
             '7.0' => false,
-            '5.6' => '4.0.11'
+            '5.6' => '4.0.11',
+            'extension_type' => self::NORMAL_EXTENSION_TYPE
         ],
         self::GEOIP_EXTENSION => [
             '7.2' => '1.1.1',
             '7.1' => '1.1.1',
-            '7.0' => '1.1.1'
-        ],
-        self::IONCUBE_LOADER_EXTENSION => [
-            '7.2' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '7.1' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '7.0' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '5.6' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            'file_extension' => self::TAR_GZ_FILE_EXTENSION,
-            'packaged_directory' => 'ioncube',
-            'custom' => true,
-            'default' => false,
-            'extension_type' => self::ZEND_EXTENSION_TYPE,
-            'extension_php_name' => 'the ionCube PHP Loader'
+            '7.0' => '1.1.1',
+            'extension_type' => self::NORMAL_EXTENSION_TYPE
         ]
     ];
 
-    var $cli, $files;
+    var $peclCustom;
 
     /**
-     * Create a new Brew instance.
-     *
-     * @param  CommandLine $cli
-     * @param  Filesystem $files
+     * @inheritdoc
      */
-    function __construct(CommandLine $cli, Filesystem $files)
+    function __construct(CommandLine $cli, Filesystem $files, PeclCustom $peclCustom)
     {
-        $this->cli = $cli;
-        $this->files = $files;
+        parent::__construct($cli, $files);
+        $this->peclCustom = $peclCustom;
     }
 
     /**
-     * Get the extension directory from the PECL config.
-     *
-     * @return mixed
+     * @inheritdoc
      */
-    function getExtensionDirectory()
+    public function installExtensions($onlyDefaults = true)
     {
-        return str_replace("\n", '', $this->cli->runAsUser('pecl config-get ext_dir'));
+        info("[PECL] Installing extensions");
+        foreach (self::EXTENSIONS as $extension => $versions) {
+            if ($onlyDefaults && $this->isDefaultExtension($extension) === false) {
+                continue;
+            }
+
+            if($this->getVersion($extension) !== false){
+                $this->installExtension($extension);
+                $this->enableExtension($extension);
+            }
+        }
     }
 
     /**
-     * Get the php.ini file path from the PECL config.
+     * Install a single extension if not already installed, default is true and has a version for this PHP version.
+     * If version equals false the extension will not be installed for this PHP version.
      *
-     * @return mixed
+     * @param $extension
+     *    The extension key name.
+     * @return bool
      */
-    function getPhpIniPath()
+    function installExtension($extension)
     {
-        $phpIniPath = str_replace("\n", '', $this->cli->runAsUser('pecl config-get php_ini'));
-
-        if(empty($phpIniPath)){
-            throw new DomainException('Pear config is missing php_ini! Try to use valet fix to solve this problem.');
+        if ($this->isInstalled($extension)) {
+            output("\t$extension is already installed, skipping...");
+            return false;
         }
 
-        return $phpIniPath;
+        $this->install($extension, $this->getVersion($extension));
+        return true;
     }
 
     /**
-     * Get the current PHP version from the PECL config.
+     * Install a single extension.
      *
-     * @return string
-     *    The php version as string: 5.6, 7.0, 7.1, 7.2
+     * @param $extension
+     *    The extension key name.
+     * @param null $version
      */
-    function getPhpVersion()
+    protected function install($extension, $version = null)
     {
-        $version = $this->cli->runAsUser('pecl version | grep PHP');
-        $version = str_replace('PHP Version:', '', $version);
-        $version = str_replace(' ', '', $version);
-        $version = substr($version, 0, 3);
-        return $version;
+        if ($version === null) {
+            $result = $this->cli->runAsUser("pecl install $extension");
+        } else {
+            $result = $this->cli->runAsUser("pecl install $extension-$version");
+        }
+
+        $alias = $this->getExtensionAlias($extension);
+        if (!preg_match("/Installing '(.*$alias.so)'/", $result)) {
+            throw new DomainException("Could not find installation path for: $extension\n\n$result");
+        }
+
+        if (strpos($result, "Error:")) {
+            throw new DomainException("Installation path found, but installation failed:\n\n$result");
+        }
+
+        $phpIniPath = $this->getPhpIniPath();
+        $phpIniFile = $this->files->get($phpIniPath);
+        if (!preg_match('/(zend_extension|extension)\="(.*' . $alias . '.so)"/', $phpIniFile, $iniMatches)) {
+            throw new DomainException("Could not find ini definition for: $extension in $phpIniPath");
+        }
+
+        output("\t$extension successfully installed");
+    }
+
+    /**
+     * Enable an single extension if not already enabled, default is true and has a version does not equal false.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return bool
+     */
+    function enableExtension($extension)
+    {
+        if ($this->isEnabled($extension) && $this->isEnabledCorrectly($extension)) {
+            output("\t$extension is already enabled, skipping...");
+            return false;
+        }
+
+        $this->enable($extension);
+        return true;
+    }
+
+    /**
+     * Enable an single extension.
+     *
+     * @param $extension
+     *    The extension key name.
+     */
+    function enable($extension)
+    {
+        $phpIniPath = $this->getPhpIniPath();
+        $phpIniFile = $this->files->get($phpIniPath);
+        $phpIniFile = $this->replaceIniDefinition($extension, $phpIniFile);
+        $phpIniFile = $this->alternativeInstall($extension, $phpIniFile);
+        $this->peclCustom->saveIniFile($phpIniPath, $phpIniFile);
+
+        output("\t$extension successfully enabled");
+    }
+
+    /**
+     * @inheritdoc
+     */
+    function uninstallExtensions()
+    {
+        info("[PECL] Removing extensions");
+        foreach (self::EXTENSIONS as $extension => $versions) {
+            if($this->getVersion($extension) !== false){
+                $this->disableExtension($extension);
+            }
+        }
+    }
+
+    /**
+     * Uninstall and disable an extension if installed.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return bool
+     *    Whether or not an uninstall happened.
+     */
+    function disableExtension($extension)
+    {
+        $version = $this->getVersion($extension);
+        if($this->isEnabled($extension)){
+            $this->disable($extension);
+        }
+        if ($this->isInstalled($extension)) {
+            $this->uninstall($extension, $version);
+            return true;
+        }
+        return false;
+    }
+
+    function disable($extension){
+        $this->removeIniDefinition($extension);
+        $this->alternativeDisable($extension);
+    }
+
+    /**
+     * Replace and remove all directives of the .so file for the given extension within the php.ini file.
+     *
+     * @param $extension
+     *    The extension key name.
+     */
+    private function removeIniDefinition($extension)
+    {
+        $phpIniPath = $this->getPhpIniPath();
+        $alias = $this->getExtensionAlias($extension);
+        $phpIniFile = $this->files->get($phpIniPath);
+        $phpIniFile = preg_replace('/;?(zend_extension|extension)\=".*' . $alias . '.so"/', '', $phpIniFile);
+        $this->peclCustom->saveIniFile($phpIniPath, $phpIniFile);
+        output("\t$extension successfully disabled");
+    }
+
+    /**
+     * Because some extensions install others, like apcu_bc, the default disable method will not be sufficient.
+     * In that case use this method to for example add additional dependencies for the specific disable. For example
+     * apcu_bc installs apcu and apc both will need to be removed from the php.ini file. The default would only remove
+     * apcu.so so we define apc.so here as alternative.
+     *
+     * @param $extension
+     * @return string
+     */
+    private function alternativeDisable($extension)
+    {
+        switch ($extension) {
+            case self::APCU_BC_EXTENSION:
+                $this->disable(self::APCU_EXTENSION);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Because some extensions install others, like apcu_bc, the default uninstall method will not be sufficient.
+     * In that case use this method to for example add additional dependencies for the specific uninstall. For example
+     * apcu_bc installs apcu and apc both will need to be uninstalled from pecl. The default would only uninstall
+     * apcu.so so we define apc.so here as alternative.
+     *
+     * @param $extension
+     * @return string
+     */
+    private function alternativeUninstall($extension)
+    {
+        switch ($extension) {
+            case self::APCU_BC_EXTENSION:
+                $version = $this->getVersion($extension);
+                $this->uninstall(self::APCU_EXTENSION, $version);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Uninstall a single extension.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @param null $version
+     */
+    private function uninstall($extension, $version = null)
+    {
+        if ($version === null || $version === false) {
+            $this->cli->passthru("pecl uninstall $extension");
+        } else {
+            $this->cli->passthru("pecl uninstall $extension-$version");
+        }
+
+        $this->alternativeUninstall($extension);
     }
 
     /**
@@ -189,463 +304,51 @@ class Pecl
     }
 
     /**
-     * Fix common problems related to the PECL/PEAR installation.
-     */
-    function fix(){
-        info('[PECL] Checking pear config...');
-        // Check if pear config is set correctly as per:
-        // https://github.com/kabel/homebrew-core/blob/2564749d8f73e43cbb8cfc449bca4f564ac0e9e1/Formula/php%405.6.rb
-        // Brew installation standard.
-        foreach (['5.6', '7.0', '7.1', '7.2'] as $phpVersion){
-            output("Checking php $phpVersion...");
-
-            $pearConfigPath = "/usr/local/etc/php/$phpVersion/pear.conf";
-
-            if(!$this->files->exists($pearConfigPath)){
-                warning("    Skipping $phpVersion, Pear config path could not be found at: $pearConfigPath");
-                continue;
-            }
-
-            $pearConfig = $this->files->get($pearConfigPath);
-            $pearConfigSplit = explode("\n", $pearConfig);
-
-            $pearConfigVersion = '';
-            $pearConfig = false;
-            foreach($pearConfigSplit as $splitValue){
-                if(strpos($splitValue, 'php_ini')){
-                    $pearConfig = unserialize($splitValue);
-                }else if(strpos($splitValue, 'Config')){
-                    $pearConfigVersion = $splitValue;
-                }else{
-                    continue;
-                }
-            }
-
-            if($pearConfig === false){
-                warning("Could not determine pear configuration for PhP version: $phpVersion, skipping...");
-                continue;
-            }
-
-            $phpIniPath = str_replace('pear.conf', 'php.ini', $pearConfigPath);
-            $phpDirPath = "/usr/local/share/pear@$phpVersion";
-            $pearDocDirPath = "/usr/local/share/pear@$phpVersion/doc";
-            $phpExtensionDirPath = '/usr/local/lib/php/pecl/'.basename($pearConfig['ext_dir']);
-            $phpBinPath = "/usr/local/opt/php@$phpVersion/bin";
-            $pearDataDirPath = "/usr/local/share/pear@$phpVersion/data";
-            $pearCfgDirPath = "/usr/local/share/pear@$phpVersion/cfg";
-            $pearWwwDirPath = "/usr/local/share/pear@$phpVersion/htdocs";
-            $pearManDirPath = '/usr/local/share/man';
-            $pearTestDirPath = "/usr/local/share/pear@$phpVersion/test";
-            $phpBinDirPath = "/usr/local/opt/php@$phpVersion/bin/php";
-
-            // PhP 7.2 doesn't work with a @ version annotation.
-            if($phpVersion === '7.2'){
-                $phpDirPath = str_replace("@$phpVersion", '', $phpDirPath);
-                $pearDocDirPath = str_replace("@$phpVersion", '', $pearDocDirPath);
-                $phpBinPath = str_replace("@$phpVersion", '', $phpBinPath);
-                $pearDataDirPath = str_replace("@$phpVersion", '', $pearDataDirPath);
-                $pearCfgDirPath = str_replace("@$phpVersion", '', $pearCfgDirPath);
-                $pearWwwDirPath = str_replace("@$phpVersion", '', $pearWwwDirPath);
-                $pearDataDirPath = str_replace("@$phpVersion", '', $pearDataDirPath);
-                $pearTestDirPath = str_replace("@$phpVersion", '', $pearTestDirPath);
-                $phpBinDirPath = str_replace("@$phpVersion", '', $phpBinDirPath);
-            }
-
-            // Check php_ini value of par config.
-            if(empty($pearConfig['php_ini']) || $pearConfig['php_ini'] !== $phpIniPath){
-                output("    Setting pear config php_ini directive to: $phpIniPath");
-                $pearConfig['php_ini'] = $phpIniPath;
-            }
-            // Check php_dir value of par config.
-            if(empty($pearConfig['php_dir']) || $pearConfig['php_dir'] !== $phpDirPath){
-                output("    Setting pear config php_dir directive to: $phpDirPath");
-                $pearConfig['php_dir'] = $phpDirPath;
-            }
-            // Check doc_dir value of par config.
-            if(empty($pearConfig['doc_dir']) || $pearConfig['doc_dir'] !== $pearDocDirPath){
-                output("    Setting pear config doc_dir directive to: $pearDocDirPath");
-                $pearConfig['doc_dir'] = $pearDocDirPath;
-            }
-            // Check ext_dir value of par config.
-            if(empty($pearConfig['ext_dir']) || $pearConfig['ext_dir'] !== $phpExtensionDirPath){
-                output("    Setting pear config ext_dir directive to: $phpExtensionDirPath");
-                $pearConfig['ext_dir'] = $phpExtensionDirPath;
-            }
-            // Check php_bin value of par config.
-            if(empty($pearConfig['bin_dir']) || $pearConfig['bin_dir'] !== $phpBinPath){
-                output("    Setting pear config bin_dir directive to: $phpBinPath");
-                $pearConfig['bin_dir'] = $phpBinPath;
-            }
-            // Check data_dir value of par config.
-            if(empty($pearConfig['data_dir']) || $pearConfig['data_dir'] !== $pearDataDirPath){
-                output("    Setting pear config data_dir directive to: $pearDataDirPath");
-                $pearConfig['data_dir'] = $pearDataDirPath;
-            }
-            // Check cfg_dir value of par config.
-            if(empty($pearConfig['cfg_dir']) || $pearConfig['cfg_dir'] !== $pearCfgDirPath){
-                output("    Setting pear config cfg_dir directive to: $pearCfgDirPath");
-                $pearConfig['cfg_dir'] = $pearCfgDirPath;
-            }
-            // Check www_dir value of par config.
-            if(empty($pearConfig['www_dir']) || $pearConfig['www_dir'] !== $pearWwwDirPath){
-                output("    Setting pear config www_dir directive to: $pearWwwDirPath");
-                $pearConfig['www_dir'] = $pearWwwDirPath;
-            }
-            // Check man_dir value of par config.
-            if(empty($pearConfig['man_dir']) || $pearConfig['man_dir'] !== $pearManDirPath){
-                output("    Setting pear config man_dir directive to: $pearManDirPath");
-                $pearConfig['man_dir'] = $pearManDirPath;
-            }
-            // Check test_dir value of par config.
-            if(empty($pearConfig['test_dir']) || $pearConfig['test_dir'] !== $pearTestDirPath){
-                output("    Setting pear config test_dir directive to: $pearTestDirPath");
-                $pearConfig['test_dir'] = $pearTestDirPath;
-            }
-            // Check php_bin value of par config.
-            if(empty($pearConfig['php_bin']) || $pearConfig['php_bin'] !== $phpBinDirPath){
-                output("    Setting pear config php_bin directive to: $phpBinDirPath");
-                $pearConfig['php_bin'] = $phpBinDirPath;
-            }
-
-            // Rebuild the config.
-            $pearConfig = serialize($pearConfig);
-            if(!empty($pearConfigVersion)){
-                $pearConfig = $pearConfigVersion."\n".$pearConfig;
-            }
-
-            // Put config back into the pear.conf file.
-            $this->files->put($pearConfigPath, $pearConfig);
-        }
-    }
-
-    /**
-     * Report to CLI whether or not the extension is installed.
-     *
-     * @param $extension
-     *    The extension key name.
+     * @inheritdoc
      */
     function isInstalled($extension)
     {
-        if ($this->installed($extension)) {
-            info("[PECL] $extension is installed");
-        } else {
-            info("[PECL] $extension is not installed");
-        }
-    }
-
-    /**
-     * Check if the extension is installed.
-     *
-     * @param $extension
-     *    The extension key name.
-     * @return bool
-     *   True if installed, false if not installed.
-     */
-    function installed($extension)
-    {
-        if ($this->isCustomExtension($extension)) {
-            // Because custom extensions are not managed by pecl check "php -m" for its existence.
-            $extensionName = $this->getExtensionName($extension);
-            return strpos($this->cli->runAsUser('php -m | grep \'' . $extensionName . '\''), $extensionName) !== false;
-        } else {
-            //@TODO: Evaluate if using php -m is more stable, package could be installed by PECL but not enabled in the php.ini file.
-            return strpos($this->cli->runAsUser('pecl list | grep ' . $extension), $extension) !== false;
-        }
-    }
-
-    /**
-     * Install a single extension.
-     *
-     * @param $extension
-     *    The extension key name.
-     * @param null $version
-     */
-    private function install($extension, $version = null)
-    {
-        if ($version === null) {
-            $result = $this->cli->runAsUser("pecl install $extension");
-        } else {
-            $result = $this->cli->runAsUser("pecl install $extension-$version");
-        }
-
-        $alias = $this->getExtensionAlias($extension);
-        $phpIniPath = $this->getPhpIniPath();
-        $phpIniFile = $this->files->get($phpIniPath);
-        $phpIniFile = $this->replaceIniDefinition($alias, $phpIniFile, $result);
-        $phpIniFile = $this->alternativeInstall($extension, $phpIniFile, $result);
-        $this->saveIniFile($phpIniPath, $phpIniFile);
-        output("$extension successfully installed");
-    }
-
-    /**
-     * Install a single custom extension.
-     *
-     * @param $extension
-     *    The extension key name.
-     * @param $url
-     */
-    function customInstall($extension, $url)
-    {
-
-        // Get file name from url
-        $urlSplit = explode('/', $url);
-        $fileName = $urlSplit[count($urlSplit) - 1];
-
-        // Check if .so is available
-        $extensionDirectory = $this->getExtensionDirectory();
-        $extensionAlias = $this->getExtensionAlias($extension);
-        if ($this->files->exists($extensionDirectory . '/' . $extensionAlias) === false) {
-            info("[PECL] $extension is not available from PECL, downloading from: $url");
-            $this->downloadExtension($extension, $url, $fileName, $extensionAlias, $extensionDirectory);
-        } else {
-            info("[PECL] $extensionAlias found in $extensionDirectory skipping download..");
-        }
-
-        // Install php.ini directive.
-        info("[PECL] Adding $extensionAlias to php.ini...");
-        $extensionType = $this->getExtensionType($extension);
-        $phpIniPath = $this->getPhpIniPath();
-        $directive = $extensionType . '="' . $extensionAlias . '"';
-        $phpIniFile = $this->files->get($phpIniPath);
-        $this->saveIniFile($phpIniPath, $directive . "\n" . $phpIniFile);
-
-        output("$extension successfully installed");
-    }
-
-    /**
-     * Download and unpack a custom extension.
-     *
-     * @param $extension
-     *    The extension key name.
-     * @param $url
-     *    The extension url
-     * @param $fileName
-     *    The file name of the packaged directory.
-     * @param $extensionAlias
-     *    The extension alias which equals the name of the .so file. E.G: xdebug.so
-     * @param $extensionDirectory
-     *    The directory where the .so file needs to be placed.
-     */
-    function downloadExtension($extension, $url, $fileName, $extensionAlias, $extensionDirectory)
-    {
-        $unpackagedDirectory = $this->getPackagedDirectory($extension);
-
-        // Download and unzip
-        $this->cli->passthru("cd /tmp && curl -O $url");
-
-        // Unpackage the file using file extension.
-        $fileExtension = $this->getFileExtension($extension);
-        switch ($fileExtension) {
-            case self::TAR_GZ_FILE_EXTENSION:
-                info('[PECL] Unpackaging .tar.gz:');
-                $this->cli->passthru("cd /tmp && tar -xvzf $fileName");
-                break;
-            default:
-                throw new DomainException("File extension $fileExtension is not supported yet!");
-        }
-
-        // Search for extension file in unpackaged directory using the extension alias.
-        $files = $this->files->scandir("/tmp/$unpackagedDirectory");
-        if (in_array($extensionAlias, $files)) {
-            info("[PECL] $extensionAlias was found, moving to extension directory: $extensionDirectory");
-            $this->cli->runAsUser("cp /tmp/$unpackagedDirectory/$extensionAlias $extensionDirectory");
-        } else {
-            throw new DomainException("$extensionAlias could not be found!");
-        }
-
-        // Remove artifacts from /tmp folder.
-        $this->cli->runAsUser("rm /tmp/$fileName");
-        $this->cli->runAsUser("rm -r /tmp/$unpackagedDirectory/$extensionAlias $extensionDirectory");
-    }
-
-    /**
-     * Uninstall a single extension.
-     *
-     * @param $extension
-     *    The extension key name.
-     * @param null $version
-     */
-    private function uninstall($extension, $version = null)
-    {
-        // Only call PECL uninstall if package is managed by PECL.
-        if ($this->isCustomExtension($extension) === false) {
-            if ($version === null || $version === false) {
-                $this->cli->passthru("pecl uninstall $extension");
-            } else {
-                $this->cli->passthru("pecl uninstall $extension-$version");
-            }
-        }
-
-        $this->removeIniDefinition($extension);
-    }
-
-    /**
-     * Uninstall all extensions defined in EXTENSIONS.
-     */
-    function uninstallExtensions()
-    {
-        info("[PECL] Removing extensions");
-        foreach (self::EXTENSIONS as $extension => $versions) {
-            $this->uninstallExtension($extension);
-        }
-    }
-
-    /**
-     * Uninstall an extension if installed, by version.
-     *
-     * @param $extension
-     *    The extension key name.
-     * @return bool
-     */
-    function uninstallExtension($extension)
-    {
-        $version = $this->getVersion($extension);
-        if ($this->installed($extension)) {
-            $this->uninstall($extension, $version);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Install all extensions defined in EXTENSIONS.
-     *
-     * @param bool $onlyDefaults
-     */
-    function installExtensions($onlyDefaults = true)
-    {
-        info("[PECL] Installing extensions");
-        foreach (self::EXTENSIONS as $extension => $versions) {
-            if ($onlyDefaults && $this->isDefaultExtension($extension) === false) {
-                continue;
-            }
-
-            $this->installExtension($extension);
-        }
-    }
-
-    /**
-     * Install a single extension if not already installed, default is true and has a version for this PHP version.
-     *
-     * If version is false the extension will never be installed for this PHP version.
-     *
-     * @param $extension
-     *    The extension key name.
-     * @return bool
-     */
-    function installExtension($extension)
-    {
-        $version = $this->getVersion($extension);
-        $isCustom = $this->isCustomExtension($extension);
-
-        if ($this->installed($extension)) {
-            return false;
-        }
-
-        if ($isCustom) {
-            $this->customInstall($extension, $version);
-        } elseif ($isCustom === false && $version !== false) {
-            $this->install($extension, $version);
-        }
-
-        return true;
+        return strpos($this->cli->runAsUser('pecl list | grep ' . $extension), $extension) !== false;
     }
 
     /**
      * Because some extensions install others, like apcu_bc, the default install method will not be sufficient.
      * In that case use this method to for example add additional dependencies for the specific install. For example
-     * apcu_bc install apcu and apc both will need to be linked within the php.ini file. The default would only link
+     * apcu_bc installs apcu and apc both will need to be linked within the php.ini file. The default would only link
      * apcu.so so we define apc.so here as alternative.
      *
      * @param $extension
+     *    The extension key name.
      * @param $phpIniFile
-     * @param $result
      * @return string
      */
-    private function alternativeInstall($extension, $phpIniFile, $result)
+    private function alternativeInstall($extension, $phpIniFile)
     {
         switch ($extension) {
             case self::APCU_BC_EXTENSION:
-                return $this->replaceIniDefinition($this->getExtensionAlias(self::APCU_EXTENSION), $phpIniFile, $result);
+                return $this->replaceIniDefinition(self::APCU_EXTENSION, $phpIniFile);
             default:
                 return $phpIniFile;
         }
     }
 
     /**
-     * Replace all definitions of the .so file to the given extension within the php.ini file.
+     * Replace the .so directive within the php.ini file. Initial .so directive will be set by
+     * 'pecl install {extension}'. Replacing will prevent duplicate entries.
      *
      * @param $extension
      *    The extension key name.
-     */
-    private function removeIniDefinition($extension)
-    {
-        $phpIniPath = $this->getPhpIniPath();
-        info("[PECL] removing $extension from: $phpIniPath");
-        $alias = $this->getExtensionAlias($extension);
-        $phpIniFile = $this->files->get($phpIniPath);
-        if ($this->isCustomExtension($extension)) {
-            $phpIniFile = preg_replace('/;?(zend_extension|extension)\=".*' . $alias . '"/', '', $phpIniFile);
-        } else {
-            $phpIniFile = preg_replace('/;?(zend_extension|extension)\=".*' . $alias . '.so"/', '', $phpIniFile);
-        }
-        $this->saveIniFile($phpIniPath, $phpIniFile);
-    }
-
-    /**
-     * Some extensions require to be loaded before others. Because the order is important within the php.ini file one
-     * should always use this method before saving the php.ini file. This method makes sure that .so definitions within
-     * the php.ini file are always ordered correctly.
-     *
-     * @param $phpIniPath
-     *    The path to the php.ini file.
      * @param $phpIniFile
-     *    The contents of the php.ini file.
-     */
-    private function saveIniFile($phpIniPath, $phpIniFile)
-    {
-        // Ioncube loader requires to be the first zend_extension loaded from the php.ini
-        // before saving the ini file check if ioncube is enabled and move it to the top of the file.
-        $ioncubeLoader = $this->getExtensionAlias(self::IONCUBE_LOADER_EXTENSION);
-        if (preg_match('/(zend_extension|extension)\="(.*' . $ioncubeLoader . ')"/', $phpIniFile, $matches)) {
-            $phpIniFile = preg_replace('/(zend_extension|extension)\="(.*' . $ioncubeLoader . ')"/', '', $phpIniFile);
-            $phpIniFile = $matches[1] . '="' . $matches[2] . '"' . "\n" . $phpIniFile;
-        }
-
-        $this->files->putAsUser($phpIniPath, $phpIniFile);
-    }
-
-    /**
-     * Replace the .so definition within the php.ini file. Initial .so definition will be set by
-     * 'pecl install {extension}'. This needs to be overriden with the value returned by the install becuase the
-     * extension_dir is not set within the php.ini file.
      *
-     * Homebrew is working for a fix that should make the PECL directory PHP specific:
-     *  https://github.com/Homebrew/homebrew-core/pull/26137
-     *
-     * @param $extension
-     * @param $phpIniFile
-     * @param $result
      * @return string
      */
-    private function replaceIniDefinition($extension, $phpIniFile, $result)
+    private function replaceIniDefinition($extension, $phpIniFile)
     {
-        if (!preg_match("/Installing '(.*$extension.so)'/", $result)) {
-            throw new DomainException("Could not find installation path for: $extension\n\n$result");
-        }
+        $alias = $this->getExtensionAlias($extension);
+        $type = $this->getExtensionType($extension);
+        $phpIniFile = preg_replace("/(zend_extension|extension)\=\"(.*$alias.so)\"/", '', $phpIniFile);
 
-        if (strpos($result, "Error:")) {
-            throw new DomainException("Installation path found, but installation failed:\n\n$result");
-        }
-
-        if (!preg_match('/(zend_extension|extension)\="(.*' . $extension . '.so)"/', $phpIniFile, $iniMatches)) {
-            $phpIniPath = $this->getPhpIniPath();
-            throw new DomainException("Could not find ini definition for: $extension in $phpIniPath");
-        }
-
-        $phpIniFile = preg_replace('/(zend_extension|extension)\="(.*' . $extension . '.so)"/', '', $phpIniFile);
-
-        return $iniMatches[1] . '="' . $iniMatches[2] . '"'."\n". $phpIniFile;
+        return "$type=\"$alias.so\"\n" . $phpIniFile;
     }
 
     /**
@@ -668,43 +371,13 @@ class Pecl
     }
 
     /**
-     * Whether or not this extension is custom. Is set by settings the 'custom' key to true within the extensions
-     * configuration. Custom extensions are not supported by PECL and will be downloaded.
-     *
-     * @param $extension
-     * @return bool
+     * @inheritdoc
      */
-    private function isCustomExtension($extension)
-    {
-        if (array_key_exists('custom', self::EXTENSIONS[$extension])) {
-            return true;
-        } elseif (array_key_exists('custom', self::EXTENSIONS[$extension]) === false) {
-            return false;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Get the extension alias for the extension.
-     *
-     * PECL managed extensions:
-     * Should return the alias of the .so file without the .so extension. E.G: apcu, apc, xdebug
-     *
-     * CUSTOM managed extensions:
-     * Should return the alias of the .so file with the .so extension. E.G: apcu.so, apc.so, xdebug.so
-     *
-     * @param $extension
-     *    The extension key name.
-     * @return string
-     */
-    private function getExtensionAlias($extension)
+    protected function getExtensionAlias($extension)
     {
         switch ($extension) {
             case self::APCU_BC_EXTENSION:
                 return self::APCU_BC_ALIAS;
-            case self::IONCUBE_LOADER_EXTENSION:
-                return self::IONCUBE_LOADER_EXTENSION . '_' . $this->getPhpVersion() . '.so';
             default:
                 return $extension;
         }
@@ -727,63 +400,37 @@ class Pecl
     }
 
     /**
-     * Get the file extension of the downloaded custom extension package.
+     * Pecl sometimes adds a directive twice. This causes the PHP installation to see the extension as
+     * installed. However the seconds directive is seen as faulty which causes the PHP installation to
+     * fail. This van be solved by checking if the directive exists twice. If it does valet-plus will
+     * deem the module as "disabled" and replace the existing directives with a single one.
      *
      * @param $extension
-     *    The extension key name.
-     * @return mixed
+     * @return bool
      */
-    private function getFileExtension($extension)
-    {
-        if (array_key_exists('file_extension', self::EXTENSIONS[$extension])) {
-            return self::EXTENSIONS[$extension]['file_extension'];
-        }
-        throw new DomainException('file_extension key is required for custom PECL packages');
+    private function isEnabledCorrectly($extension){
+        $phpIniPath = $this->getPhpIniPath();
+        $phpIniFile = $this->files->get($phpIniPath);
+        $type = $this->getExtensionType($extension);
+        $alias = $this->getExtensionAlias($extension);
+        preg_match_all("/$type=\"$alias.so\"/m", $phpIniFile, $matches);
+        $alternativeEnabledCorrectly = $this->isAlternativeEnabledCorrectly($extension);
+        $isEnabledCorrectly = $alternativeEnabledCorrectly && (is_array($matches) && count($matches) === 1?count($matches[0]) === 1:false);
+        return $isEnabledCorrectly;
     }
 
     /**
-     * Get the directory within the packaged archive.
+     * Alternative case for checking directives of modules that depend on other modules.
      *
      * @param $extension
-     *    The extension key name.
-     * @return mixed
+     * @return bool
      */
-    private function getPackagedDirectory($extension)
-    {
-        if (array_key_exists('packaged_directory', self::EXTENSIONS[$extension])) {
-            return self::EXTENSIONS[$extension]['packaged_directory'];
+    private function isAlternativeEnabledCorrectly($extension){
+        switch ($extension) {
+            case self::APCU_BC_EXTENSION:
+                return $this->isEnabledCorrectly(self::APCU_EXTENSION);
+            default:
+                return true;
         }
-        throw new DomainException('packaged_directory key is required for custom PECL packages');
     }
-
-    /**
-     * Get the extension type: zend_extension or extension for the custom extension.
-     *
-     * @param $extension
-     *    The extension key name.
-     * @return mixed
-     */
-    private function getExtensionType($extension)
-    {
-        if (array_key_exists('extension_type', self::EXTENSIONS[$extension])) {
-            return self::EXTENSIONS[$extension]['extension_type'];
-        }
-        throw new DomainException('extension_type key is required for custom PECL packages');
-    }
-
-    /**
-     * Get the extension name for the custom extension. Used for checking php -m output.
-     *
-     * @param $extension
-     *    The extension key name.
-     * @return mixed
-     */
-    private function getExtensionName($extension)
-    {
-        if (array_key_exists('extension_php_name', self::EXTENSIONS[$extension])) {
-            return self::EXTENSIONS[$extension]['extension_php_name'];
-        }
-        throw new DomainException('extension_php_name key is required for custom PECL packages');
-    }
-
 }

--- a/cli/Valet/PeclCustom.php
+++ b/cli/Valet/PeclCustom.php
@@ -1,0 +1,438 @@
+<?php
+
+namespace Valet;
+
+use Exception;
+use DomainException;
+
+class PeclCustom extends AbstractPecl
+{
+
+    // Extensions.
+    const IONCUBE_LOADER_EXTENSION = 'ioncube_loader_dar';
+
+    // File extensions.
+    const TAR_GZ_FILE_EXTENSION = '.tar.gz';
+
+    /**
+     * Supported pecl extensions for the PECL manager. There are 2 types of extensions supported: zend_extensions and
+     * extensions. Not all extension are available through PECL. This class handles custom packages that are not managed
+     * by PECL.
+     *
+     * CUSTOM example:
+     *
+     * Packages that are not available through PECL can be downloaded. Every PHP version requires a download link
+     * so the manager can download the .so file for the active PHP version.
+     *
+     * .so files can be packages by different file extensions. Use the file_extension key to set the file extension
+     * of the downloaded file.
+     *
+     * Because packages files can contain a directory with a different name the manager will be unable to find the
+     * unpacked folder. Set packaged_directory so that it equals the folder name after unpacking the folder.
+     *
+     * Downloaded extensions can either be of type zend_extension or extension. Because the manager does not know
+     * what kind of extension the downloaded.so file is one defines extension_type with one of the extension types.
+     *
+     * To check if the extension is active the manager uses extension_php_name. The manager check of php -m returns the
+     * extension name.
+     *
+     * @formatter:off
+     *
+     * 'extension_key_name' => [
+     *    '7.2' => 'https://example.com/packagename.extension',
+     *    '7.1' => 'https://example.com/packagename.extension',
+     *    '7.0' => 'https://example.com/packagename.extension',
+     *    '5.6' => 'https://example.com/packagename.extension',
+     *    'file_extension' => self::TAR_GZ_FILE_EXTENSION,
+     *    'extension_type' => self::ZEND_EXTENSION_TYPE,
+     *    'extension_php_name' => 'the ionCube PHP Loader',
+     * ]
+     *
+     * @formatter:on
+     */
+    const EXTENSIONS = [
+        self::IONCUBE_LOADER_EXTENSION => [
+            '7.2' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
+            '7.1' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
+            '7.0' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
+            '5.6' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
+            'file_extension' => self::TAR_GZ_FILE_EXTENSION,
+            'packaged_directory' => 'ioncube',
+            'default' => false,
+            'extension_type' => self::ZEND_EXTENSION_TYPE,
+            'extension_php_name' => 'the ionCube PHP Loader'
+        ]
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    function __construct(CommandLine $cli, Filesystem $files)
+    {
+        parent::__construct($cli, $files);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    function installExtensions($onlyDefaults = true)
+    {
+        info("[PECL-CUSTOM] Installing extensions");
+        foreach (self::EXTENSIONS as $extension => $versions) {
+            if ($onlyDefaults && $this->isDefaultExtension($extension) === false) {
+                continue;
+            }
+
+            $this->installExtension($extension);
+            $this->enableExtension($extension);
+        }
+    }
+
+    /**
+     * Install a single extension if not already installed, default is true and has a version for this PHP version.
+     * If version equals false the extension will never be installed for this PHP version.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return bool
+     */
+    function installExtension($extension)
+    {
+        $version = $this->getVersion($extension);
+
+        if ($this->isInstalled($extension)) {
+            output("\t$extension is already installed, skipping...");
+            return false;
+        }
+
+        $this->install($extension, $version);
+
+        return true;
+    }
+
+    /**
+     * Install a single custom extension.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @param $url
+     */
+    function install($extension, $url)
+    {
+
+        // Get file name from url
+        $urlSplit = explode('/', $url);
+        $fileName = $urlSplit[count($urlSplit) - 1];
+
+        // Check if .so is available
+        $extensionDirectory = $this->getExtensionDirectory();
+        $extensionAlias = $this->getExtensionAlias($extension);
+        if ($this->files->exists($extensionDirectory . '/' . $extensionAlias) === false) {
+            info("[PECL-CUSTOM] $extension is not available from PECL, downloading from: $url");
+            $this->downloadExtension($extension, $url, $fileName, $extensionAlias, $extensionDirectory);
+        } else {
+            info("[PECL-CUSTOM] $extensionAlias found in $extensionDirectory skipping download..");
+        }
+
+        output("\t$extension successfully installed");
+    }
+
+    /**
+     * Download and unpack a custom extension.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @param $url
+     *    The extension url
+     * @param $fileName
+     *    The file name of the packaged directory.
+     * @param $extensionAlias
+     *    The extension alias which equals the name of the .so file. E.G: xdebug.so
+     * @param $extensionDirectory
+     *    The directory where the .so file needs to be placed.
+     */
+    function downloadExtension($extension, $url, $fileName, $extensionAlias, $extensionDirectory)
+    {
+        $unpackagedDirectory = $this->getPackagedDirectory($extension);
+
+        // Download and unzip
+        $this->cli->passthru("cd /tmp && sudo -u ".user()." curl -O $url");
+
+        // Unpackage the file using file extension.
+        $fileExtension = $this->getFileExtension($extension);
+        switch ($fileExtension) {
+            case self::TAR_GZ_FILE_EXTENSION:
+                info('[PECL-CUSTOM] Unpackaging .tar.gz:');
+                $this->cli->passthru("cd /tmp && sudo -u ".user()." tar -xvzf $fileName");
+                break;
+            default:
+                throw new DomainException("File extension $fileExtension is not supported yet!");
+        }
+
+        // Search for extension file in unpackaged directory using the extension alias.
+        $files = $this->files->scandir("/tmp/$unpackagedDirectory");
+        if (in_array($extensionAlias, $files)) {
+            info("[PECL-CUSTOM] $extensionAlias was found, moving to extension directory: $extensionDirectory");
+            $this->cli->runAsUser("cp /tmp/$unpackagedDirectory/$extensionAlias $extensionDirectory/");
+        } else {
+            throw new DomainException("$extensionAlias could not be found!");
+        }
+
+        // Remove artifacts from /tmp folder.
+        $this->cli->runAsUser("rm /tmp/$fileName");
+        $this->cli->runAsUser("rm -r /tmp/$unpackagedDirectory");
+    }
+
+    /**
+     * Enable an single extension if not already enabled, default is true and has a version for this PHP version.
+     *
+     * If version is false the extension will never be installed for this PHP version.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return bool
+     */
+    function enableExtension($extension)
+    {
+        if ($this->isEnabled($extension)) {
+            output("\t$extension is already enabled, skipping...");
+            return false;
+        }
+
+        $this->enable($extension);
+        return true;
+    }
+
+    /**
+     * Install a single custom extension.
+     *
+     * @param $extension
+     *    The extension key name.
+     */
+    function enable($extension)
+    {
+        // Install php.ini directive.
+        $extensionAlias = $this->getExtensionAlias($extension);
+        $extensionType = $this->getExtensionType($extension);
+        $phpIniPath = $this->getPhpIniPath();
+        $directive = $extensionType . '="' . $extensionAlias . '"';
+        $phpIniFile = $this->files->get($phpIniPath);
+        $this->saveIniFile($phpIniPath, $directive . "\n" . $phpIniFile);
+
+        output("\t$extension successfully enabled");
+    }
+
+    /**
+     * @inheritdoc
+     */
+    function uninstallExtensions()
+    {
+        info("[PECL-CUSTOM] Removing extensions");
+        foreach (self::EXTENSIONS as $extension => $versions) {
+            $this->uninstallExtension($extension);
+        }
+    }
+
+    /**
+     * Uninstall an extension if installed, by version.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return bool
+     */
+    function uninstallExtension($extension)
+    {
+        $version = $this->getVersion($extension);
+        if($this->isEnabled($extension)){
+            $this->disable($extension);
+        }
+        if ($this->isInstalled($extension)) {
+            $this->uninstall($extension, $version);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Disable a single extension.
+     *
+     * @param $extension
+     */
+    function disable($extension){
+        $this->removeIniDefinition($extension);
+    }
+
+    /**
+     * Uninstall a single extension.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @param null $version
+     */
+    private function uninstall($extension, $version = null)
+    {
+        // Check if .so is available
+        $extensionDirectory = $this->getExtensionDirectory();
+        $extensionAlias = $this->getExtensionAlias($extension);
+        $filePath = $extensionDirectory . '/' . $extensionAlias;
+        if ($this->files->exists($filePath)) {
+            $this->cli->runAsUser("rm $filePath");
+            output("\t$extension successfully uninstalled.");
+        }else{
+            output("\t$extension was already removed!");
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    function isInstalled($extension)
+    {
+        $extensionDirectory = $this->getExtensionDirectory();
+        $extensionAlias = $this->getExtensionAlias($extension);
+        return $this->files->exists($extensionDirectory . '/' . $extensionAlias);
+    }
+
+    /**
+     * Replace all definitions of the .so file to the given extension within the php.ini file.
+     *
+     * @param $extension
+     *    The extension key name.
+     */
+    private function removeIniDefinition($extension)
+    {
+        $phpIniPath = $this->getPhpIniPath();
+        $alias = $this->getExtensionAlias($extension);
+        $phpIniFile = $this->files->get($phpIniPath);
+        $phpIniFile = preg_replace('/;?(zend_extension|extension)\=".*' . $alias . '"/', '', $phpIniFile);
+        $this->saveIniFile($phpIniPath, $phpIniFile);
+        output("\t$extension successfully disabled");
+    }
+
+    /**
+     * Some extensions require to be loaded before others. Because the order is important within the php.ini file one
+     * should always use this method before saving the php.ini file. This method makes sure that .so definitions within
+     * the php.ini file are always ordered correctly.
+     *
+     * @param $phpIniPath
+     *    The path to the php.ini file.
+     * @param $phpIniFile
+     *    The contents of the php.ini file.
+     */
+    public function saveIniFile($phpIniPath, $phpIniFile)
+    {
+        // Ioncube loader requires to be the first zend_extension loaded from the php.ini
+        // before saving the ini file check if ioncube is enabled and move it to the top of the file.
+        $ioncubeLoader = $this->getExtensionAlias(self::IONCUBE_LOADER_EXTENSION);
+        if (preg_match('/(zend_extension|extension)\="(.*' . $ioncubeLoader . ')"/', $phpIniFile, $matches)) {
+            $phpIniFile = preg_replace('/(zend_extension|extension)\="(.*' . $ioncubeLoader . ')"/', '', $phpIniFile);
+            $phpIniFile = $matches[1] . '="' . $matches[2] . '"' . "\n" . $phpIniFile;
+        }
+
+        $this->files->putAsUser($phpIniPath, $phpIniFile);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isEnabled($extension)
+    {
+        $alias = $this->getExtensionName($extension);
+        $extensions = explode("\n", $this->cli->runAsUser("php -m | grep '$alias'"));
+        return in_array($alias, $extensions);
+    }
+
+    /**
+     * Whether or not this extension should be enabled by default. Is set by setting the
+     * 'default' key to true within the extensions configuration.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return bool
+     */
+    private function isDefaultExtension($extension)
+    {
+        if (array_key_exists('default', self::EXTENSIONS[$extension])) {
+            return false;
+        } elseif (array_key_exists('default', self::EXTENSIONS[$extension]) === false) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getExtensionAlias($extension)
+    {
+        switch ($extension) {
+            case self::IONCUBE_LOADER_EXTENSION:
+                return self::IONCUBE_LOADER_EXTENSION . '_' . $this->getPhpVersion() . '.so';
+            default:
+                return $extension;
+        }
+    }
+
+    /**
+     * Get the version of the extension supported by the current PHP version.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return null
+     */
+    private function getVersion($extension)
+    {
+        $phpVersion = $this->getPhpVersion();
+        if (array_key_exists($phpVersion, self::EXTENSIONS[$extension])) {
+            return self::EXTENSIONS[$extension][$phpVersion];
+        }
+        return null;
+    }
+
+    /**
+     * Get the file extension of the downloaded custom extension package.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return mixed
+     */
+    private function getFileExtension($extension)
+    {
+        if (array_key_exists('file_extension', self::EXTENSIONS[$extension])) {
+            return self::EXTENSIONS[$extension]['file_extension'];
+        }
+        throw new DomainException('file_extension key is required for custom PECL packages');
+    }
+
+    /**
+     * Get the directory within the packaged archive.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return mixed
+     */
+    private function getPackagedDirectory($extension)
+    {
+        if (array_key_exists('packaged_directory', self::EXTENSIONS[$extension])) {
+            return self::EXTENSIONS[$extension]['packaged_directory'];
+        }
+        throw new DomainException('packaged_directory key is required for custom PECL packages');
+    }
+
+    /**
+     * Get the extension name for the custom extension. Used for checking php -m output.
+     *
+     * @param $extension
+     *    The extension key name.
+     * @return mixed
+     */
+    private function getExtensionName($extension)
+    {
+        if (array_key_exists('extension_php_name', self::EXTENSIONS[$extension])) {
+            return self::EXTENSIONS[$extension]['extension_php_name'];
+        }
+        throw new DomainException('extension_php_name key is required for custom PECL packages');
+    }
+
+}

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -6,7 +6,7 @@ use DomainException;
 
 class PhpFpm
 {
-    var $brew, $cli, $files, $pecl;
+    var $brew, $cli, $files, $pecl, $peclCustom;
 
     const DEPRECATED_PHP_TAP = 'homebrew/php';
 
@@ -17,12 +17,13 @@ class PhpFpm
      * @param  CommandLine $cli
      * @param  Filesystem $files
      */
-    function __construct(Brew $brew, CommandLine $cli, Filesystem $files, Pecl $pecl)
+    function __construct(Brew $brew, CommandLine $cli, Filesystem $files, Pecl $pecl, PeclCustom $peclCustom)
     {
         $this->cli = $cli;
         $this->brew = $brew;
         $this->files = $files;
         $this->pecl = $pecl;
+        $this->peclCustom = $peclCustom;
     }
 
     /**
@@ -42,6 +43,7 @@ class PhpFpm
         $this->updateConfiguration();
         $this->pecl->updatePeclChannel();
         $this->pecl->installExtensions($version);
+        $this->peclCustom->installExtensions($version);
         $this->restart();
     }
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -305,22 +305,24 @@ class PhpFpm
     /**
      * Fixes common problems with php installations from Homebrew.
      */
-    function fix(){
+    function fix($reinstall){
         // Remove old homebrew/php tap packages.
         info('Removing all old php56- packages from homebrew/php tap');
-        $this->cli->passthru('brew list | grep php56- | xargs brew uninstall');
+        output($this->cli->runAsUser('brew list | grep php56- | xargs brew uninstall'));
         info('Removing all old php70- packages from homebrew/php tap');
-        $this->cli->passthru('brew list | grep php70- | xargs brew uninstall');
+        output($this->cli->runAsUser('brew list | grep php70- | xargs brew uninstall'));
         info('Removing all old php71- packages from homebrew/php tap');
-        $this->cli->passthru('brew list | grep php71- | xargs brew uninstall');
+        output($this->cli->runAsUser('brew list | grep php71- | xargs brew uninstall'));
         info('Removing all old php72- packages from homebrew/php tap');
-        $this->cli->passthru('brew list | grep php72- | xargs brew uninstall');
+        output($this->cli->runAsUser('brew list | grep php72- | xargs brew uninstall'));
 
+        // Remove deprecated n98-magerun packages.
         info('Removing all old n98-magerun packages from homebrew/php tap');
-        $this->cli->passthru('brew list | grep n98-magerun | xargs brew uninstall');
+        output($this->cli->runAsUser('brew list | grep n98-magerun | xargs brew uninstall'));
 
+        // Remove homebrew/php tap.
         info('Removing drush package from homebrew/php tap');
-        $this->cli->passthru('brew list | grep drush | xargs brew uninstall');
+        output($this->cli->runAsUser('brew list | grep drush | xargs brew uninstall'));
 
         // Disable extensions that are not managed by the PECL manager or within php core.
         $deprecatedVersions = ['5.6', '7.0', '7.1', '7.2'];
@@ -337,21 +339,25 @@ class PhpFpm
             }
         }
 
-        info('Trying to remove php56...');
-        $this->cli->passthru('brew uninstall php56');
-        info('Trying to remove php70...');
-        $this->cli->passthru('brew uninstall php70');
-        info('Trying to remove php71...');
-        $this->cli->passthru('brew uninstall php71');
-        info('Trying to remove php72...');
-        $this->cli->passthru('brew uninstall php72');
+        // If full reinstall is required remove PHP formulae. This will also uninstall formulae in the following format:
+        // php@{version}.
+        if($reinstall){
+            info('Trying to remove php56...');
+            output($this->cli->runAsUser('brew uninstall php56'));
+            info('Trying to remove php70...');
+            output($this->cli->runAsUser('brew uninstall php70'));
+            info('Trying to remove php71...');
+            output($this->cli->runAsUser('brew uninstall php71'));
+            info('Trying to remove php72...');
+            output($this->cli->runAsUser('brew uninstall php72'));
+        }
 
         // If the current php is not 7.1, link 7.1.
         info('Installing and linking new PHP homebrew/core version.');
-        $this->cli->passthru('brew uninstall ' . Brew::PHP_V71_FORMULAE);
-        $this->cli->passthru('brew install ' . Brew::PHP_V71_FORMULAE);
-        $this->cli->passthru('brew unlink '. Brew::PHP_V71_FORMULAE);
-        $this->cli->passthru('brew link '.Brew::PHP_V71_FORMULAE.' --force --overwrite');
+        output($this->cli->runAsUser('brew uninstall ' . Brew::PHP_V71_FORMULAE));
+        output($this->cli->runAsUser('brew install ' . Brew::PHP_V71_FORMULAE));
+        output($this->cli->runAsUser('brew unlink '. Brew::PHP_V71_FORMULAE));
+        output($this->cli->runAsUser('brew link '.Brew::PHP_V71_FORMULAE.' --force --overwrite'));
 
         if ($this->brew->hasTap(self::DEPRECATED_PHP_TAP)) {
             info('[brew] untapping formulae ' . self::DEPRECATED_PHP_TAP);
@@ -360,7 +366,7 @@ class PhpFpm
 
         warning("Please check your linked php version, you might need to restart your terminal!".
             "\nLinked PHP should be php 7.1:");
-        $this->cli->passthru('php -v');
+        output($this->cli->runAsUser('php -v'));
     }
 
     /**

--- a/cli/includes/facades.php
+++ b/cli/includes/facades.php
@@ -31,6 +31,7 @@ class Facade
 
 class Brew extends Facade {}
 class Pecl extends Facade {}
+class PeclCustom extends Facade {}
 class Binaries extends Facade{}
 class Nginx extends Facade {}
 class Mysql extends Facade {}

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -64,8 +64,9 @@ $app->command('install [--with-mariadb]', function ($withMariadb) {
 /**
  * Fix common problems within the Valet+ installation.
  */
-$app->command('fix', function () {
-    PhpFpm::fix();
+$app->command('fix [--reinstall]', function ($reinstall) {
+    PhpFpm::fix($reinstall);
+    Pecl::fix();
 })->descriptions('Fixes common installation problems that prevent Valet+ from working');
 
 /**

--- a/valet
+++ b/valet
@@ -20,9 +20,6 @@ then
     DIR=$(php -r "echo realpath('$DIR/../laravel/valet');")
 fi
 
-# If the command is one of the commands that requires "sudo" privileges
-# then we'll proxy the incoming CLI request using sudo, which allows
-# us to never require the end users to manually specify each sudo.
 if [[ "$EUID" -ne 0 ]]
 then
     sudo $SOURCE "$@"


### PR DESCRIPTION
PR for: https://github.com/weprovide/valet-plus/issues/139

P.S: Sorry for adding so many changes within a single PR/Commit. Had to do some restructuring within the previous realised PECL manager to prevent massive duplication of the code.

Notable changes:
- `valet fix` now has a `--reinstall` option which makes the command reinstall all installed php installations.
- PECL has been divided into "Pecl" and "PeclCustom". All packages that are not supported by PECL will be added to "PeclCustom".
- There is now a AbstractPecl class which shares functionality between "Pecl" and "PeclCustom".
- Removed forgotten comment within the valet binary as mentioned by another contributor within the Gitter chatroom.