### PR TITLE
Support for Nginx proxying instead of Valet Driver

### DIFF
--- a/cli/stubs/proxy.valet.conf
+++ b/cli/stubs/proxy.valet.conf
@@ -1,0 +1,34 @@
+server {
+    listen 80;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location / {
+        proxy_set_header HOST $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection “upgrade”;
+
+        proxy_http_version 1.1;
+        proxy_pass VALET_PROXY_PASS;
+    }
+
+    access_log off;
+    error_log VALET_HOME_PATH/Log/nginx-error.log;
+
+    error_page 404 VALET_SERVER_PATH;
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/cli/stubs/secure.proxy.valet.conf
+++ b/cli/stubs/secure.proxy.valet.conf
@@ -1,0 +1,43 @@
+server {
+    listen 80;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location / {
+        proxy_set_header HOST $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection “upgrade”;
+
+        proxy_http_version 1.1;
+        proxy_pass VALET_PROXY_PASS;
+    }
+
+    ssl_certificate VALET_CERT;
+    ssl_certificate_key VALET_KEY;
+
+    access_log off;
+    error_log VALET_HOME_PATH/Log/nginx-error.log;
+
+    error_page 404 VALET_SERVER_PATH;
+
+    location ~ /\.ht {
+        deny all;
+    }
+}


### PR DESCRIPTION
As of late, we've been using Swoole and a few SPAs while still using Valet for other projects. The downside, is currently Valet drivers do not support reverse proxying to allow for all cases. 

Swoole is the main driving force for us but also Nuxt.js. Hot loading doesn't function in Nuxt without proxying since the files are never really compiled so a static driver would not work.

This PR adds the ability to convert a site over to proxy mode which will redirect traffic to a specified url (host and port) instead of sending it off to the Valet driver. 

In the interest of streamlining and keeping the code base clean, we also refactored the secure and unsecure methods to a configure that sets everything up. 