### PR TITLE
Add support for MFTF MagentoCLI commands

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -169,6 +169,10 @@ class Magento2ValetDriver extends ValetDriver
             exit;
         }
 
+        if(strpos($uri, '/dev/tests/acceptance/utils/command.php') !== false) {
+            return $sitePath . '/dev/tests/acceptance/utils/command.php';
+        }
+
         $_SERVER['DOCUMENT_ROOT'] = $sitePath;
 
         return $sitePath . '/pub/index.php';


### PR DESCRIPTION
Magento's new functional testing framework, [MFTF](https://devdocs.magento.com/guides/v2.2/magento-functional-testing-framework/release-1/introduction.html) has the ability to run [Magento CLI](https://devdocs.magento.com/guides/v2.2/magento-functional-testing-framework/release-2/test/actions.html#magentocli) commands from within the test framework. As the test framework runs independently of the Magento installation it completes these via HTTP to the `command.php` script located in the `dev/tests/acceptance/utils` folder.

The Magento 2 valet driver does not support the `.htaccess` entry added by Magento core and thus requires an additional entry to correctly route this operation.