### PR TITLE
Serve M2 js-translation.json in production mode

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -101,12 +101,12 @@ class Magento2ValetDriver extends ValetDriver
             $uri = '/static' . $resource;
         }
 
-        if (strpos($uri, '/js-translation.json') === false && file_exists($staticFilePath = $sitePath . '/pub' . $uri)) {
-            return $staticFilePath;
+        if (strpos($uri, '/js-translation.json') !== false) {
+            header('Cache-Control: no-store, must-revalidate');
         }
 
-        if(strpos($uri, '/js-translation.json') !== false) {
-            header('Cache-Control: no-store, must-revalidate');
+        if (file_exists($staticFilePath = $sitePath . '/pub' . $uri)) {
+            return $staticFilePath;
         }
 
         if (strpos($uri, '/static/') === 0) {


### PR DESCRIPTION
Make M2 js-translation.json work in production mode.
Closes issue https://github.com/weprovide/valet-plus/issues/219