### PR TITLE
Optimize database settings when running valet configure

### DIFF
--- a/assets/sql/magento2-settings.sql
+++ b/assets/sql/magento2-settings.sql
@@ -1,10 +1,10 @@
--- Update all dev settings to false
+-- Update all dev settings (css merge, js merge, asset minification, static signing) to false
 UPDATE `core_config_data`
 SET `value` = 0
 WHERE (`path` REGEXP '^dev.*')
 AND `value` = 1;
 
--- Update Sphinx when using Mirasvit Sphinx Search
+-- Update sphinx search engine to mysql
 UPDATE `core_config_data`
 SET `value` = 'mysql2'
 WHERE `value` = 'sphinx';

--- a/assets/sql/magento2-settings.sql
+++ b/assets/sql/magento2-settings.sql
@@ -1,0 +1,20 @@
+-- Update all dev settings to false
+UPDATE `core_config_data`
+SET `value` = 0
+WHERE (`path` REGEXP '^dev.*')
+AND `value` = 1;
+
+-- Update Sphinx when using Mirasvit Sphinx Search
+UPDATE `core_config_data`
+SET `value` = 'mysql2'
+WHERE `value` = 'sphinx';
+
+-- Update base_urls from www to non www
+UPDATE `core_config_data`
+SET `value` = replace(`value`, 'https://www.', 'https://')
+WHERE (`path` REGEXP '^web/.*/base_url$');
+
+-- Update base_urls file extensions to .test
+UPDATE `core_config_data`
+SET `value` = replace(replace(replace(`value`, '.be', '.test'), '.de', '.test'), '.nl', '.test')
+WHERE (`path` REGEXP '^web/.*/base_url$');

--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -25,16 +25,15 @@ class Magento2ValetDriver extends ValetDriver
             $devtools->cli->quietlyAsUser('bin/magento module:enable --all');
         }
 
-        info('Setting base url...');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set web/unsecure/base_url ' . $url . '/');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set web/secure/base_url ' . $url . '/');
+        info('Preparing Magento 2 for local development...');
+        $devtools->cli->quietlyAsUser("n98-magerun2 db:import {$this->sqlSettingsPath()}");
 
         info('Setting elastic search hostname...');
         $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set catalog/search/elasticsearch_server_hostname 127.0.0.1');
-        
+
         info('Enabling URL rewrites...');
         $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set web/seo/use_rewrites 1');
-        
+
         info('Flushing cache...');
         $devtools->cli->quietlyAsUser('n98-magerun2 cache:flush');
 
@@ -79,7 +78,7 @@ class Magento2ValetDriver extends ValetDriver
     {
         $isMagentoStatic = false;
         $resource = $uri;
-        
+
         if(strpos($uri,'/errors') === 0 && file_exists($sitePath.'/pub'.$uri)) {
             return $sitePath.'/pub'.$uri;
         }
@@ -139,7 +138,7 @@ class Magento2ValetDriver extends ValetDriver
         if(isset($_GET['profile'])) {
             $_SERVER['MAGE_PROFILER'] = 'html';
         }
-        
+
         if(strpos($uri, '/errors') === 0) {
             $file = $sitePath . '/pub' . $uri;
             if (file_exists($file)) {
@@ -180,4 +179,21 @@ class Magento2ValetDriver extends ValetDriver
 
         return $sitePath . '/pub/index.php';
     }
+
+    public function valetDir()
+    {
+        $currentPath = realpath(dirname(__FILE__));
+        $valetPath = dirname(dirname($currentPath));
+        return $valetPath;
+    }
+
+    protected function sqlSettingsPath()
+    {
+        $location = $this->valetDir() . '/assets/sql/magento2-settings.sql';
+        if(!file_exists($location)) {
+            throw new \Exception('Settings Sql file missing');
+        }
+        return $location;
+    }
+
 }


### PR DESCRIPTION
When setting up a local development environment with Valet Plus, I usually have to manually adjust several settings in the database before I can start developing. For example:
- Fixing the base urls
- If CSS/JS merging is enabled in developer mode requests will take up to 30 seconds
- Switching the search engine to mysql if the client is using sphinx

To fix these issues, we can add a sql file to the repo and automatically import it using `n98-magerun2` when running `valet configure`. 

What to you guys think about this approach?