### PR TITLE
Replace Magerun commands with Magento commands during configure

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -26,17 +26,17 @@ class Magento2ValetDriver extends ValetDriver
         }
 
         info('Setting base url...');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set web/unsecure/base_url ' . $url . '/');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set web/secure/base_url ' . $url . '/');
+        $devtools->cli->quietlyAsUser('bin/magento config:set web/unsecure/base_url ' . $url . '/');
+        $devtools->cli->quietlyAsUser('bin/magento config:set web/secure/base_url ' . $url . '/');
 
         info('Setting elastic search hostname...');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set catalog/search/elasticsearch_server_hostname 127.0.0.1');
+        $devtools->cli->quietlyAsUser('bin/magento config:set catalog/search/elasticsearch_server_hostname 127.0.0.1');
         
         info('Enabling URL rewrites...');
-        $devtools->cli->quietlyAsUser('n98-magerun2 config:store:set web/seo/use_rewrites 1');
+        $devtools->cli->quietlyAsUser('bin/magento config:set web/seo/use_rewrites 1');
         
         info('Flushing cache...');
-        $devtools->cli->quietlyAsUser('n98-magerun2 cache:flush');
+        $devtools->cli->quietlyAsUser('bin/magento cache:flush');
 
         info('Configured Magento 2');
     }


### PR DESCRIPTION
This resolves issues with `valet configure` on environments that do not have n98-magerun for Magento 2