### PR TITLE
Set constants for PHP brewnames to easily handle default and non-default PHP versions

### DIFF
--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -311,7 +311,7 @@ class Pecl extends AbstractPecl
         // Check if pear config is set correctly as per:
         // https://github.com/kabel/homebrew-core/blob/2564749d8f73e43cbb8cfc449bca4f564ac0e9e1/Formula/php%405.6.rb
         // Brew installation standard.
-        foreach (['5.6', '7.0', '7.1', '7.2'] as $phpVersion){
+        foreach (Brew::SUPPORTED_PHP_FORMULAE as $phpVersion => $brewname) {
             output("Checking php $phpVersion...");
 
             $pearConfigPath = "/usr/local/etc/php/$phpVersion/pear.conf";
@@ -341,30 +341,19 @@ class Pecl extends AbstractPecl
                 continue;
             }
 
-            $phpIniPath = str_replace('pear.conf', 'php.ini', $pearConfigPath);
-            $phpDirPath = "/usr/local/share/pear@$phpVersion";
-            $pearDocDirPath = "/usr/local/share/pear@$phpVersion/doc";
-            $phpExtensionDirPath = '/usr/local/lib/php/pecl/'.basename($pearConfig['ext_dir']);
-            $phpBinPath = "/usr/local/opt/php@$phpVersion/bin";
-            $pearDataDirPath = "/usr/local/share/pear@$phpVersion/data";
-            $pearCfgDirPath = "/usr/local/share/pear@$phpVersion/cfg";
-            $pearWwwDirPath = "/usr/local/share/pear@$phpVersion/htdocs";
-            $pearManDirPath = '/usr/local/share/man';
-            $pearTestDirPath = "/usr/local/share/pear@$phpVersion/test";
-            $phpBinDirPath = "/usr/local/opt/php@$phpVersion/bin/php";
+            $pearName = $this->replacePhpWithPear($brewname);
 
-            // PhP 7.2 doesn't work with a @ version annotation.
-            if($phpVersion === '7.2'){
-                $phpDirPath = str_replace("@$phpVersion", '', $phpDirPath);
-                $pearDocDirPath = str_replace("@$phpVersion", '', $pearDocDirPath);
-                $phpBinPath = str_replace("@$phpVersion", '', $phpBinPath);
-                $pearDataDirPath = str_replace("@$phpVersion", '', $pearDataDirPath);
-                $pearCfgDirPath = str_replace("@$phpVersion", '', $pearCfgDirPath);
-                $pearWwwDirPath = str_replace("@$phpVersion", '', $pearWwwDirPath);
-                $pearDataDirPath = str_replace("@$phpVersion", '', $pearDataDirPath);
-                $pearTestDirPath = str_replace("@$phpVersion", '', $pearTestDirPath);
-                $phpBinDirPath = str_replace("@$phpVersion", '', $phpBinDirPath);
-            }
+            $phpIniPath = str_replace('pear.conf', 'php.ini', $pearConfigPath);
+            $phpDirPath = "/usr/local/share/$pearName";
+            $pearDocDirPath = "/usr/local/share/$pearName/doc";
+            $phpExtensionDirPath = '/usr/local/lib/php/pecl/'.basename($pearConfig['ext_dir']);
+            $phpBinPath = "/usr/local/opt/$brewname/bin";
+            $pearDataDirPath = "/usr/local/share/$pearName/data";
+            $pearCfgDirPath = "/usr/local/share/$pearName/cfg";
+            $pearWwwDirPath = "/usr/local/share/$pearName/htdocs";
+            $pearManDirPath = '/usr/local/share/man';
+            $pearTestDirPath = "/usr/local/share/$pearName/test";
+            $phpBinDirPath = "/usr/local/opt/$brewname/bin/php";
 
             // Check php_ini value of par config.
             if(empty($pearConfig['php_ini']) || $pearConfig['php_ini'] !== $phpIniPath){
@@ -562,5 +551,9 @@ class Pecl extends AbstractPecl
             default:
                 return true;
         }
+    }
+
+    private function replacePhpWithPear($brewname) {
+        return str_replace('php', 'pear', $brewname);
     }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -130,10 +130,10 @@ class PhpFpm
     function fpmConfigPath()
     {
         $confLookup = [
-            $this->sanitizeVersion(Brew::PHP_V72_FORMULAE) => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
-            $this->sanitizeVersion(Brew::PHP_V71_FORMULAE) => '/usr/local/etc/php/7.1/php-fpm.d/www.conf',
-            $this->sanitizeVersion(Brew::PHP_V70_FORMULAE) => '/usr/local/etc/php/7.0/php-fpm.d/www.conf',
-            $this->sanitizeVersion(Brew::PHP_V56_FORMULAE) => '/usr/local/etc/php/5.6/php-fpm.conf',
+            Brew::PHP_V72_VERSION => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
+            Brew::PHP_V71_VERSION => '/usr/local/etc/php/7.1/php-fpm.d/www.conf',
+            Brew::PHP_V70_VERSION => '/usr/local/etc/php/7.0/php-fpm.d/www.conf',
+            Brew::PHP_V56_VERSION => '/usr/local/etc/php/5.6/php-fpm.conf',
         ];
 
         return $confLookup[$this->brew->linkedPhp()];
@@ -144,11 +144,10 @@ class PhpFpm
      */
     function switchTo($version)
     {
-        $versions = $this->sanitizeVersion(Brew::SUPPORTED_PHP_FORMULAE);
         $currentVersion = $this->brew->linkedPhp();
 
-        if(!in_array($version, $versions)){
-            throw new DomainException("This version of PHP not available. The following versions are available: " . implode(' ', $versions));
+        if(!isset(BREW::SUPPORTED_PHP_FORMULAE[$version])){
+            throw new DomainException("This version of PHP not available. The following versions are available: " . implode(' ', array_keys(BREW::SUPPORTED_PHP_FORMULAE)));
         }
 
         // If the current version equals that of the current PHP version, do not switch.
@@ -158,28 +157,25 @@ class PhpFpm
         }
 
         info("[php@$currentVersion] Unlinking");
-        output($this->cli->runAsUser('brew unlink php@' . $currentVersion));
+        output($this->cli->runAsUser('brew unlink ' . BREW::SUPPORTED_PHP_FORMULAE[$currentVersion]));
 
         info('[libjpeg] Relinking');
         $this->cli->passthru('sudo ln -fs /usr/local/Cellar/jpeg/8d/lib/libjpeg.8.dylib /usr/local/opt/jpeg/lib/libjpeg.8.dylib');
 
-        $installed = $this->brew->installed('php@' . $version);
+        $installed = $this->brew->installed(BREW::SUPPORTED_PHP_FORMULAE[$version]);
         if (!$installed) {
-            $this->brew->ensureInstalled('php@' . $version);
+            $this->brew->ensureInstalled(BREW::SUPPORTED_PHP_FORMULAE[$version]);
         }
 
-        // If php@7.2 was not installed, it installed and automagically linked itself.
-        // If we try to link it again it will throw an already linked warning.
-        // PHP 5.6, 7.0 and 7.1 do not show this behaviour probably because they're not the default formulae.
-        if(!(!$installed && $version === $this->sanitizeVersion(Brew::PHP_V72_FORMULAE))){
+        if($installed){
             info("[php@$version] Linking");
-            output($this->cli->runAsUser('brew unlink php@' . $version));
-            output($this->cli->runAsUser('brew link php@' . $version.' --force --overwrite'));
+            output($this->cli->runAsUser('brew unlink ' . BREW::SUPPORTED_PHP_FORMULAE[$version]));
+            output($this->cli->runAsUser('brew link ' . BREW::SUPPORTED_PHP_FORMULAE[$version].' --force --overwrite'));
         }
 
         $this->stop();
         $this->install();
-        info("Valet is now using php@$version");
+        info("Valet is now using ".BREW::SUPPORTED_PHP_FORMULAE[$version]);
     }
 
     /**
@@ -361,10 +357,10 @@ class PhpFpm
 
         // If the current php is not 7.1, link 7.1.
         info('Installing and linking new PHP homebrew/core version.');
-        output($this->cli->runAsUser('brew uninstall ' . Brew::PHP_V71_FORMULAE));
-        output($this->cli->runAsUser('brew install ' . Brew::PHP_V71_FORMULAE));
-        output($this->cli->runAsUser('brew unlink '. Brew::PHP_V71_FORMULAE));
-        output($this->cli->runAsUser('brew link '.Brew::PHP_V71_FORMULAE.' --force --overwrite'));
+        output($this->cli->runAsUser('brew uninstall ' . Brew::PHP_V71_BREWNAME));
+        output($this->cli->runAsUser('brew install ' . Brew::PHP_V71_BREWNAME));
+        output($this->cli->runAsUser('brew unlink '. Brew::PHP_V71_BREWNAME));
+        output($this->cli->runAsUser('brew link '.Brew::PHP_V71_BREWNAME.' --force --overwrite'));
 
         if ($this->brew->hasTap(self::DEPRECATED_PHP_TAP)) {
             info('[brew] untapping formulae ' . self::DEPRECATED_PHP_TAP);
@@ -374,25 +370,5 @@ class PhpFpm
         warning("Please check your linked php version, you might need to restart your terminal!".
             "\nLinked PHP should be php 7.1:");
         output($this->cli->runAsUser('php -v'));
-    }
-
-    /**
-     * Strips 'php@' from a string or array of strings.
-     *
-     * @param $argument
-     * @return array|mixed
-     */
-    private function sanitizeVersion($argument)
-    {
-        if(is_array($argument)){
-            foreach($argument as $key => $version){
-                $argument[$key] = str_replace('php@', '', $version);
-            }
-        }else{
-            $argument = str_replace('php@', '', $argument);
-        }
-
-
-        return $argument;
     }
 }


### PR DESCRIPTION
This fixes issue https://github.com/weprovide/valet-plus/issues/196. 

By defining the brew names of the different PHP versions as constants all "PHP 7.2" checks in the code can be removed. It also prevents changing all those checks to "PHP 7.3" in the future when PHP 7.3 becomes the standard version.