### PR TITLE
Check if the .my.cnf file exists and throw an warning if it does

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -66,6 +66,10 @@ $app->command('install [--with-mariadb]', function ($withMariadb) {
  * Fix common problems within the Valet+ installation.
  */
 $app->command('fix [--reinstall]', function ($reinstall) {
+    if (file_exists($_SERVER['HOME'] . '/.my.cnf')) {
+        warning('You have an .my.cnf file in you home directory. This can affect the mysql installation negatively.');
+    }
+
     PhpFpm::fix($reinstall);
     Pecl::fix();
 })->descriptions('Fixes common installation problems that prevent Valet+ from working');


### PR DESCRIPTION
Hi,

This morning i had a fresh install of my mac. After installing Valet Plus i couldn't get mysql started. After some time debugging i found out this was caused by some settings i had in my `.my.cnf`, which was restored using Mackup. I added a warning in the `valet fix` command when the `.my.cnf` file exists to save other people from making this mistake.