### PR TITLE
Add PHP 7.3 formulae and rename the 7.2 brew version

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -13,13 +13,16 @@ class Brew
     const PHP_V71_VERSION = '7.1';
     const PHP_V71_BREWNAME = 'php@7.1';
     const PHP_V72_VERSION = '7.2';
-    const PHP_V72_BREWNAME = 'php';
+    const PHP_V72_BREWNAME = 'php@7.2';
+    const PHP_V73_VERSION = '7.3';
+    const PHP_V73_BREWNAME = 'php';
 
     const SUPPORTED_PHP_FORMULAE = [
         self::PHP_V56_VERSION => self::PHP_V56_BREWNAME,
         self::PHP_V70_VERSION => self::PHP_V70_BREWNAME,
         self::PHP_V71_VERSION => self::PHP_V71_BREWNAME,
-        self::PHP_V72_VERSION => self::PHP_V72_BREWNAME
+        self::PHP_V72_VERSION => self::PHP_V72_BREWNAME,
+        self::PHP_V73_VERSION => self::PHP_V73_BREWNAME
     ];
 
     var $cli, $files;

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -130,6 +130,7 @@ class PhpFpm
     function fpmConfigPath()
     {
         $confLookup = [
+            Brew::PHP_V73_VERSION => '/usr/local/etc/php/7.3/php-fpm.d/www.conf',
             Brew::PHP_V72_VERSION => '/usr/local/etc/php/7.2/php-fpm.d/www.conf',
             Brew::PHP_V71_VERSION => '/usr/local/etc/php/7.1/php-fpm.d/www.conf',
             Brew::PHP_V70_VERSION => '/usr/local/etc/php/7.0/php-fpm.d/www.conf',

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -66,6 +66,15 @@ php7');
     public function test_has_installed_php_indicates_if_php_is_installed_via_brew()
     {
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(true);
+        $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
+        $brew->shouldReceive('installed')->with('php@5.6')->andReturn(false);
+        $this->assertTrue($brew->hasInstalledPhp());
+
+        $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(true);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
@@ -73,6 +82,7 @@ php7');
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(true);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
@@ -80,6 +90,7 @@ php7');
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(true);
@@ -87,6 +98,7 @@ php7');
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);
@@ -94,6 +106,7 @@ php7');
         $this->assertTrue($brew->hasInstalledPhp());
 
         $brew = Mockery::mock(Brew::class.'[installed]', [new CommandLine, new Filesystem]);
+        $brew->shouldReceive('installed')->with('php')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.2')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.1')->andReturn(false);
         $brew->shouldReceive('installed')->with('php@7.0')->andReturn(false);


### PR DESCRIPTION
PHP 7.3 was released to which the default brew php now points.