### PR TITLE
Makes supported php versions more dynamic

### DIFF
--- a/cli/Valet/AbstractPecl.php
+++ b/cli/Valet/AbstractPecl.php
@@ -26,9 +26,7 @@ abstract class AbstractPecl
      *
      * @formatter:on
      **/
-    const EXTENSIONS = [
-
-    ];
+    const EXTENSIONS = [];
 
     var $cli, $files;
 
@@ -50,7 +48,7 @@ abstract class AbstractPecl
      */
     protected function getExtensionType($extension)
     {
-        if (array_key_exists('extension_type', $this::EXTENSIONS[$extension])) {
+        if (isset($this::EXTENSIONS[$extension]['extension_type'])) {
             return $this::EXTENSIONS[$extension]['extension_type'];
         }
         throw new DomainException('extension_type key is required for PECL packages');
@@ -84,16 +82,32 @@ abstract class AbstractPecl
     /**
      * Get the current PHP version from the PECL config.
      *
+     * @param $part_count
+     *    The number of version parts to return (default = 2)
+     *
      * @return string
-     *    The php version as string: 5.6, 7.0, 7.1, 7.2, 7.3
+     *    The php version as string: 5.6, 7.0, 7.1, 7.2, 7.3, etc..
      */
-    protected function getPhpVersion()
+    protected function getPhpVersion($part_count = 2)
     {
         $version = $this->cli->runAsUser('pecl version | grep PHP');
         $version = str_replace('PHP Version:', '', $version);
-        $version = str_replace(' ', '', $version);
-        $version = substr($version, 0, 3);
-        return $version;
+
+        $parts = explode('.', trim($version));
+        $parts = array_slice($parts, 0, $part_count);
+
+        return implode('.', $parts);
+    }
+
+    /**
+     * Get the current major PHP version from the PECL config.
+     *
+     * @return string
+     *    The php version as string: 5, 7
+     */
+    protected function getMajorPhpVersion()
+    {
+        return $this->getPhpVersion(1);
     }
 
     /**

--- a/cli/Valet/Binaries.php
+++ b/cli/Valet/Binaries.php
@@ -179,7 +179,7 @@ class Binaries
      */
     private function getUrl($binary)
     {
-        if (array_key_exists('url', self::SUPPORTED_CUSTOM_BINARIES[$binary])) {
+        if (isset(self::SUPPORTED_CUSTOM_BINARIES[$binary]['url'])) {
             return self::SUPPORTED_CUSTOM_BINARIES[$binary]['url'];
         }
         throw new DomainException('url key is required for binaries.');
@@ -195,7 +195,7 @@ class Binaries
      */
     private function getShasum($binary)
     {
-        if (array_key_exists('shasum', self::SUPPORTED_CUSTOM_BINARIES[$binary])) {
+        if (isset(self::SUPPORTED_CUSTOM_BINARIES[$binary]['shasum'])) {
             return self::SUPPORTED_CUSTOM_BINARIES[$binary]['shasum'];
         }
         throw new DomainException('shasum key is required for binaries.');
@@ -211,7 +211,7 @@ class Binaries
      */
     private function getBinLocation($binary)
     {
-        if (array_key_exists('bin_location', self::SUPPORTED_CUSTOM_BINARIES[$binary])) {
+        if (isset(self::SUPPORTED_CUSTOM_BINARIES[$binary]['bin_location'])) {
             return self::SUPPORTED_CUSTOM_BINARIES[$binary]['bin_location'] . $binary;
         }
         throw new DomainException('bin_location key is required for binaries.');

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -6,7 +6,7 @@ use DomainException;
 
 class Brew
 {
-    const PHP_DEFAULT_BREWNAME = 'php';
+    const DEFAULT_PHP_NAME = 'php';
     const SUPPORTED_PHP_VERSIONS = [
         '5[6]',
         '7[0-99]'
@@ -52,7 +52,7 @@ class Brew
             $this->supported_php_formulae[$version] = 'php@' . $version;
         }
 
-        $this->supported_php_formulae[$this->corePhpVersion()] = self::PHP_DEFAULT_BREWNAME;
+        $this->supported_php_formulae[$this->corePhpVersion()] = self::DEFAULT_PHP_NAME;
     }
 
     /**

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -294,6 +294,10 @@ class Brew
     function linkedPhp()
     {
         if (!$this->files->isLink('/usr/local/bin/php')) {
+            $this->cli->runAsUser('brew link php');
+        }
+
+        if (!$this->files->isLink('/usr/local/bin/php')) {
             throw new DomainException("Unable to determine linked PHP.");
         }
 
@@ -306,7 +310,6 @@ class Brew
                 return $version;
             }
         }
-
 
         throw new DomainException("Unable to determine linked PHP.");
     }

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -8,8 +8,8 @@ class Brew
 {
     const PHP_DEFAULT_BREWNAME = 'php';
     const SUPPORTED_PHP_VERSIONS = [
-        '5.6',
-        '7' // will dynamically add all minor versions of 7
+        '5[6]',
+        '7[0-99]'
     ];
 
     var $supported_php_formulae = [];
@@ -31,22 +31,18 @@ class Brew
         $supported_php_versions = [];
 
         foreach (self::SUPPORTED_PHP_VERSIONS as $version) {
-            // reached core php version, so stop
-            if ($version > $core_php_version) {
-                break;
-            }
+            preg_match('/([0-9]+)\[([0-9]+)(?:-([0-9]+))?\]/', $version, $match);
 
-            if (strpos($version, '.') !== false) {
-                $supported_php_versions[] = $version;
-                continue;
-            }
+            $major = $match[1];
+            $minor_from = $match[2];
+            $minor_to = isset($match[3]) ? $match[3] : $minor_from;
 
             // add all minor versions of major number, with the core php version as max
-            for ($i = 0; $i < 10; $i++) {
-                $supported_php_versions[] = $version . '.' . $i;
+            for ($i = $minor_from; $i <= $minor_to; $i++) {
+                $supported_php_versions[] = $major . '.' . $i;
 
                 // reached core php version, so stop
-                if ($version . '.' . $i >= $core_php_version) {
+                if ($major . '.' . $i >= $core_php_version) {
                     break;
                 }
             }

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -2,12 +2,10 @@
 
 namespace Valet;
 
-use Exception;
 use DomainException;
 
 class Pecl extends AbstractPecl
 {
-
     // Extensions.
     const XDEBUG_EXTENSION = 'xdebug';
     const APCU_EXTENSION = 'apcu';
@@ -50,6 +48,7 @@ class Pecl extends AbstractPecl
             'extension_type' => self::NORMAL_EXTENSION_TYPE
         ],
         self::APCU_EXTENSION => [
+            '7.3' => false,
             '7.2' => false,
             '7.1' => false,
             '7.0' => false,
@@ -57,6 +56,7 @@ class Pecl extends AbstractPecl
             'extension_type' => self::NORMAL_EXTENSION_TYPE
         ],
         self::GEOIP_EXTENSION => [
+            '7.3' => '1.1.1',
             '7.2' => '1.1.1',
             '7.1' => '1.1.1',
             '7.0' => '1.1.1',
@@ -64,14 +64,15 @@ class Pecl extends AbstractPecl
         ]
     ];
 
-    var $peclCustom;
+    var $brew, $peclCustom;
 
     /**
      * @inheritdoc
      */
-    function __construct(CommandLine $cli, Filesystem $files, PeclCustom $peclCustom)
+    function __construct(Brew $brew, CommandLine $cli, Filesystem $files, PeclCustom $peclCustom)
     {
         parent::__construct($cli, $files);
+        $this->brew = $brew;
         $this->peclCustom = $peclCustom;
     }
 
@@ -311,7 +312,7 @@ class Pecl extends AbstractPecl
         // Check if pear config is set correctly as per:
         // https://github.com/kabel/homebrew-core/blob/2564749d8f73e43cbb8cfc449bca4f564ac0e9e1/Formula/php%405.6.rb
         // Brew installation standard.
-        foreach (Brew::SUPPORTED_PHP_FORMULAE as $phpVersion => $brewname) {
+        foreach ($this->brew->supported_php_formulae as $phpVersion => $brewname) {
             output("Checking php $phpVersion...");
 
             $pearConfigPath = "/usr/local/etc/php/$phpVersion/pear.conf";

--- a/cli/Valet/PeclCustom.php
+++ b/cli/Valet/PeclCustom.php
@@ -39,6 +39,7 @@ class PeclCustom extends AbstractPecl
      * @formatter:off
      *
      * 'extension_key_name' => [
+     *    '7.3' => 'https://example.com/packagename.extension',
      *    '7.2' => 'https://example.com/packagename.extension',
      *    '7.1' => 'https://example.com/packagename.extension',
      *    '7.0' => 'https://example.com/packagename.extension',
@@ -52,6 +53,7 @@ class PeclCustom extends AbstractPecl
      */
     const EXTENSIONS = [
         self::IONCUBE_LOADER_EXTENSION => [
+            '7.3' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
             '7.2' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
             '7.1' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
             '7.0' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',

--- a/cli/Valet/PeclCustom.php
+++ b/cli/Valet/PeclCustom.php
@@ -39,11 +39,8 @@ class PeclCustom extends AbstractPecl
      * @formatter:off
      *
      * 'extension_key_name' => [
-     *    '7.3' => 'https://example.com/packagename.extension',
-     *    '7.2' => 'https://example.com/packagename.extension',
-     *    '7.1' => 'https://example.com/packagename.extension',
-     *    '7.0' => 'https://example.com/packagename.extension',
      *    '5.6' => 'https://example.com/packagename.extension',
+     *    '7.*' => 'https://example.com/packagename.extension',
      *    'file_extension' => self::TAR_GZ_FILE_EXTENSION,
      *    'extension_type' => self::ZEND_EXTENSION_TYPE,
      *    'extension_php_name' => 'the ionCube PHP Loader',
@@ -53,14 +50,11 @@ class PeclCustom extends AbstractPecl
      */
     const EXTENSIONS = [
         self::IONCUBE_LOADER_EXTENSION => [
-            '7.3' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '7.2' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '7.1' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '7.0' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
+            'default' => false,
             '5.6' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
+            '7' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
             'file_extension' => self::TAR_GZ_FILE_EXTENSION,
             'packaged_directory' => 'ioncube',
-            'default' => false,
             'extension_type' => self::ZEND_EXTENSION_TYPE,
             'extension_php_name' => 'the ionCube PHP Loader'
         ]
@@ -354,13 +348,11 @@ class PeclCustom extends AbstractPecl
      */
     private function isDefaultExtension($extension)
     {
-        if (array_key_exists('default', self::EXTENSIONS[$extension])) {
-            return false;
-        } elseif (array_key_exists('default', self::EXTENSIONS[$extension]) === false) {
-            return true;
-        } else {
+        if (!isset(self::EXTENSIONS[$extension]['default'])) {
             return false;
         }
+
+        return self::EXTENSIONS[$extension]['default'];
     }
 
     /**
@@ -401,7 +393,7 @@ class PeclCustom extends AbstractPecl
      */
     private function getFileExtension($extension)
     {
-        if (array_key_exists('file_extension', self::EXTENSIONS[$extension])) {
+        if (isset(self::EXTENSIONS[$extension]['file_extension'])) {
             return self::EXTENSIONS[$extension]['file_extension'];
         }
         throw new DomainException('file_extension key is required for custom PECL packages');
@@ -416,7 +408,7 @@ class PeclCustom extends AbstractPecl
      */
     private function getPackagedDirectory($extension)
     {
-        if (array_key_exists('packaged_directory', self::EXTENSIONS[$extension])) {
+        if (isset(self::EXTENSIONS[$extension]['packaged_directory'])) {
             return self::EXTENSIONS[$extension]['packaged_directory'];
         }
         throw new DomainException('packaged_directory key is required for custom PECL packages');
@@ -431,7 +423,7 @@ class PeclCustom extends AbstractPecl
      */
     private function getExtensionName($extension)
     {
-        if (array_key_exists('extension_php_name', self::EXTENSIONS[$extension])) {
+        if (isset(self::EXTENSIONS[$extension]['extension_php_name'])) {
             return self::EXTENSIONS[$extension]['extension_php_name'];
         }
         throw new DomainException('extension_php_name key is required for custom PECL packages');

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -34,7 +34,7 @@ class PhpFpm
     function install()
     {
         if (! $this->brew->hasInstalledPhp()) {
-            $this->brew->ensureInstalled(Brew::PHP_DEFAULT_BREWNAME);
+            $this->brew->ensureInstalled(Brew::DEFAULT_PHP_NAME);
         }
 
         $version = $this->brew->linkedPhp();
@@ -318,7 +318,7 @@ class PhpFpm
         // Remove old homebrew/php tap packages.
         foreach ($this->brew->supported_php_formulae as $version => $brew_version) {
             // Skip core php version
-            if ($brew_version == BREW::PHP_DEFAULT_BREWNAME) {
+            if ($brew_version == BREW::DEFAULT_PHP_NAME) {
                 continue;
             }
 
@@ -340,7 +340,7 @@ class PhpFpm
         $deprecatedExtensions = ['apcu', 'intl', 'mcrypt'];
         foreach ($this->brew->supported_php_formulae as $version => $brew_version) {
             // Skip core php version
-            if ($brew_version == BREW::PHP_DEFAULT_BREWNAME) {
+            if ($brew_version == BREW::DEFAULT_PHP_NAME) {
                 continue;
             }
 
@@ -361,7 +361,7 @@ class PhpFpm
         if ($reinstall) {
             foreach ($this->brew->supported_php_formulae as $version => $brew_version) {
                 // Skip core php version
-                if ($brew_version == BREW::PHP_DEFAULT_BREWNAME) {
+                if ($brew_version == BREW::DEFAULT_PHP_NAME) {
                     continue;
                 }
 
@@ -372,10 +372,10 @@ class PhpFpm
 
         // If the current php is not the default.
         info('Installing and linking new PHP homebrew/core version.');
-        output($this->cli->runAsUser('brew uninstall ' . Brew::PHP_DEFAULT_BREWNAME));
-        output($this->cli->runAsUser('brew install ' . Brew::PHP_DEFAULT_BREWNAME));
-        output($this->cli->runAsUser('brew unlink '. Brew::PHP_DEFAULT_BREWNAME));
-        output($this->cli->runAsUser('brew link '.Brew::PHP_DEFAULT_BREWNAME.' --force --overwrite'));
+        output($this->cli->runAsUser('brew uninstall ' . Brew::DEFAULT_PHP_NAME));
+        output($this->cli->runAsUser('brew install ' . Brew::DEFAULT_PHP_NAME));
+        output($this->cli->runAsUser('brew unlink '. Brew::DEFAULT_PHP_NAME));
+        output($this->cli->runAsUser('brew link '.Brew::DEFAULT_PHP_NAME.' --force --overwrite'));
 
         if ($this->brew->hasTap(self::DEPRECATED_PHP_TAP)) {
             info('[brew] untapping formulae ' . self::DEPRECATED_PHP_TAP);

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -149,7 +149,7 @@ class PhpFpm
     {
         $currentVersion = $this->brew->linkedPhp();
 
-        if (!array_key_exists($version, $this->brew->supported_php_formulae)) {
+        if (!isset($this->brew->supported_php_formulae[$version])) {
             throw new DomainException("This version of PHP not available. The following versions are available: " . implode(' ', array_keys($this->brew->supported_php_formulae)));
         }
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -147,6 +147,7 @@ class PhpFpm
      */
     function switchTo($version)
     {
+        $version = $version == 'latest' ? $this->brew->corePhpVersion() : $version;
         $currentVersion = $this->brew->linkedPhp();
 
         if (!isset($this->brew->supported_php_formulae[$version])) {


### PR DESCRIPTION
This PR will make the supported php versions list more dynamic.
It will look for the core php version (installed by brew) and use that as the max.

It improves upon: #272

There is some hard-coded php versions in `PhpFpm.php` => `checkInstallation()` (~285).
This can probably be rewritten, but I am not sure what that code does.
The comments there don't make sense (no errors found, so throw an error?)