### PR TITLE
support "symfony/process" 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php": ">=5.6",
         "illuminate/container": "~5.1",
         "mnapoli/silly": "~1.5.0",
-        "symfony/process": "~2.7|~3.0",
+        "symfony/process": "~2.7|~3.0|~4.0",
         "nategood/httpful": "~0.2",
         "tightenco/collect": "~5.4.0",
         "sebastian/version": "^2.0"


### PR DESCRIPTION
it's already support on original valet