### PR TITLE
Update KirbyValetDriver.php for Kirby CMS v3

### DIFF
--- a/cli/drivers/KirbyValetDriver.php
+++ b/cli/drivers/KirbyValetDriver.php
@@ -31,7 +31,6 @@ class KirbyValetDriver extends ValetDriver
 
        return false;
     }
-
     /**
      * Get the fully resolved path to the application's front controller.
      *
@@ -42,12 +41,11 @@ class KirbyValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-        $this->loadServerEnvironmentVariables($sitePath, $siteName);
 
         // Needed to force Kirby to use *.test to generate its URLs...
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
-        if (preg_match('/^\/panel/', $uri)) {
+        if (preg_match('/^\/panel/', $uri) && file_exists($sitePath . '/panel/index.php')) {
             $_SERVER['SCRIPT_NAME'] = '/panel/index.php';
 
             return $sitePath.'/panel/index.php';


### PR DESCRIPTION
Adds the most recent changes from https://github.com/laravel/valet/blob/master/cli/drivers/KirbyValetDriver.php to ensure that the admin panel of the upcoming Kirby CMS 3 works with Valet+.