### PR TITLE
No force https to support share on ssl (#288)

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,12 +1,8 @@
 server {
     listen 80;
-    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
-    return 301 https://$host$request_uri;
-}
-
-server {
     listen 443 ssl http2;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+
     root /;
     charset utf-8;
     client_max_body_size 128M;


### PR DESCRIPTION
When using `valet secure` and then `valet share` the ngrok created URL does not work because the nginx conf forces https on the secured domain. This fix no longer forces https but supports both http and https. After this `valet share` on a secured domain works.

Magento redirects to a secured domain if configure in `core_config` table, so no worries there. Other apps might loose auto redirecting from http to https.