### PR TITLE
Remove --with-http2 option on Nginx install

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -40,7 +40,7 @@ class Nginx
     function install()
     {
         if (!$this->brew->hasInstalledNginx()) {
-            $this->brew->installOrFail('nginx', ['--with-http2']);
+            $this->brew->installOrFail('nginx');
         }
 
         $this->installConfiguration();


### PR DESCRIPTION
HTTP/2 is now included in the base package (see here: https://www.nginx.com/blog/nginx-1-13-9-http2-server-push/).  Fixes #314.