### PR TITLE
Add valet start with php switch

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -277,9 +277,23 @@ if (is_dir(VALET_HOME_PATH)) {
      * Start the daemon services.
      */
     $app->command('start [services]*', function ($services) {
-        if(empty($services)) {
+        $phpVersion = false;
+
+        if (!empty($services)) {
+            // Check if services contains a php version so we can switch to it immediately.
+            $phpVersions = array_keys(\Valet\PhpFpm::SUPPORTED_PHP_FORMULAE);
+            $intersect   = array_intersect($services, $phpVersions);
+            $phpVersion  = end($intersect);
+            $services    = array_diff($services, $phpVersions);
+        }
+
+        if (empty($services)) {
             DnsMasq::restart();
-            PhpFpm::restart();
+            if ($phpVersion) {
+                PhpFpm::switchTo($phpVersion);
+            } else {
+                PhpFpm::restart();
+            }
             Nginx::restart();
             Mysql::restart();
             RedisTool::restart();
@@ -288,6 +302,7 @@ if (is_dir(VALET_HOME_PATH)) {
             RabbitMq::restart();
             Varnish::restart();
             info('Valet services have been started.');
+
             return;
         }
 
@@ -303,7 +318,11 @@ if (is_dir(VALET_HOME_PATH)) {
                     break;
                 }
                 case 'php': {
-                    PhpFpm::restart();
+                    if ($phpVersion) {
+                        PhpFpm::switchTo($phpVersion);
+                    } else {
+                        PhpFpm::restart();
+                    }
                     break;
                 }
                 case 'redis': {


### PR DESCRIPTION
I sometimes have a scenario when I'm working with valet using php 7.1. Then turn valet off to work with on an ancient version of php with MAMP. Then go to work with valet again but then with php 7.0 or 7.2 or 5.6. In these scenarios I first have to start valet again and then switch php versions (or other way around).

It's for my convenience to be able to start valet with another version of php in one command. This PR does that.

`valet start 7.1`