### PR TITLE
Fix issue with XDebug on PHPStorm: empty server name

### DIFF
--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -25,6 +25,7 @@ server {
         fastcgi_index VALET_SERVER_PATH;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME VALET_SERVER_PATH;
+        fastcgi_param SERVER_NAME $host;
     }
 
     location ~ /\.ht {


### PR DESCRIPTION
This makes it possible to use XDebug properly with PHPStorm. 

Tested on a single Magento2 project only – but theoretically it should also work for Magento1 and most other platforms.