### PR TITLE
Longer FastGCI timeout for local development with XDebug

### DIFF
--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -21,6 +21,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_read_timeout 3600;
         fastcgi_pass unix:VALET_HOME_PATH/valet.sock;
         fastcgi_index VALET_SERVER_PATH;
         include fastcgi_params;


### PR DESCRIPTION
Allow for a (generous) FastCGI timeout of up to 1 hour for local dev sites - useful to avoid Gateway Timeouts caused by XDebug during long step-by-step debugging sessions.