### PR TITLE
Pimcore >= 5.5 versioning using Composer

### DIFF
--- a/cli/Valet/Composer.php
+++ b/cli/Valet/Composer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Valet;
+
+class Composer {
+    private $cli;
+    private $cachedPackages;
+
+    public function __construct(CommandLine $cli)
+    {
+        $this->cli = $cli;
+        $this->cachedPackages = null;
+    }
+
+    function getPackages($directory)
+    {
+        if($this->cachedPackages === null) {
+            $packages = explode(PHP_EOL, $this->cli->runCommand('composer show -d ' . $directory));
+            $associations = [];
+
+            foreach($packages as $package) {
+                $parsed = $this->parsePackage($package);
+
+                if($parsed !== null) {
+                    $associations[$parsed['name']] = $parsed;
+                }
+            }
+
+            $this->cachedPackages = $associations;
+        }
+
+        return $this->cachedPackages;
+    }
+
+    function getPackage($package, $directory)
+    {
+        $packages = $this->getPackages($directory);
+        return isset($packages[$package]) ? $packages[$package] : null;
+    }
+
+    function isInstalled($package, $directory)
+    {
+        return isset($this->getPackages($directory)[$package]);
+    }
+
+    function parsePackage($package)
+    {
+        $data = array_values(array_filter(explode(' ', $package), function($bit) {
+            return $bit;
+        }));
+
+        return ($data ? [
+            'name' => $data[0],
+            'version' => (isset($data[1]) ? $data[1] : null)
+        ] : null);
+    }
+}

--- a/cli/drivers/ValetDriver.php
+++ b/cli/drivers/ValetDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Container\Container;
+
 abstract class ValetDriver
 {
     /**
@@ -62,7 +64,7 @@ abstract class ValetDriver
         }
 
         foreach ($drivers as $driver) {
-            $driverInstance = new $driver;
+            $driverInstance = Container::getInstance()->make($driver);
 
             if ($driverInstance->serves($sitePath, $siteName, $driverInstance->mutateUri($uri))) {
                 // Cache the valet driver for a specific site for 1 hour

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -10,6 +10,10 @@ if (file_exists(__DIR__.'/../vendor/autoload.php')) {
     require __DIR__.'/../../../autoload.php';
 }
 
+require_once __DIR__ . '/includes/compatibility.php';
+require_once __DIR__ . '/includes/facades.php';
+require_once __DIR__ . '/includes/helpers.php';
+
 use Silly\Application;
 use Illuminate\Container\Container;
 use Symfony\Component\Console\Question\ConfirmationQuestion;

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,6 @@
         }
     ],
     "autoload": {
-        "files": [
-            "cli/includes/compatibility.php",
-            "cli/includes/facades.php",
-            "cli/includes/helpers.php"
-        ],
         "psr-4": {
             "Valet\\": "cli/Valet/"
         }

--- a/server.php
+++ b/server.php
@@ -1,4 +1,7 @@
 <?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+use Illuminate\Container\Container;
 
 /**
  * Define the user's "~/.valet" path.
@@ -6,6 +9,8 @@
 
 define('VALET_HOME_PATH', posix_getpwuid(fileowner(__FILE__))['dir'].'/.valet');
 define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
+
+Container::setInstance(new Container);
 
 /**
  * Load the Valet configuration.


### PR DESCRIPTION
Pimcore changed some of the file structure (as explained in #323) in version 5.5.

#323 made the necessary changes to the Pimcore driver, but these changes weren't backward compatible.

In this PR the Pimcore driver uses one or the other file structures based on the package version of "pimcore/pimcore" in Composer.

I made this a "Draft pull request" because I do not yet know whether I like my decision to extract the autoload files from the composer configuration. If they stay in the composer configuration the compatibility checks evaluate to false and exit, because they are written for the CLI.

I also want to refactor the instantiation of the `Composer` class a bit so that it uses the factory pattern to pass the site path, and not on method invocation.

Any feedback and suggestions are appreciated!