### PR TITLE
Read userpath from current user instead of file owner

### DIFF
--- a/server.php
+++ b/server.php
@@ -4,7 +4,7 @@
  * Define the user's "~/.valet" path.
  */
 
-define('VALET_HOME_PATH', posix_getpwuid(fileowner(__FILE__))['dir'].'/.valet');
+define('VALET_HOME_PATH', posix_getpwuid(posix_geteuid())['dir'].'/.valet');
 define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
 
 /**


### PR DESCRIPTION
I had issues using valet-plus on a shared macbook. Valet only seemed to work for the user who initially installed it. This is because the `VALET_HOME_PATH` is configured by reading the file owner's user. I changed this to the current logged in user as seen in the current PR.