### PR TITLE
Update secure.valet.conf

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -27,10 +27,12 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_read_timeout 3600;
         fastcgi_pass unix:VALET_HOME_PATH/valet.sock;
         fastcgi_index VALET_SERVER_PATH;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME VALET_SERVER_PATH;
+        fastcgi_param SERVER_NAME $host;
     }
 
     location ~ /\.ht {


### PR DESCRIPTION
This brings the `secure.valet.conf` file up to date with these recent changes to the `valet.conf` file:

- Include `fastcgi_read_timeout` setting (see #326)
- Include `fastcgi_param SERVER_NAME` setting (see #325)

I don't know whether any similar changes are necessary for the `secure.proxy.valet.conf` and `proxy.valet.conf` files, since proxying is different than using Fast CGI.