### PR TITLE
[TASK] Secure Domain Longer FastGCI timeout for local development

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -31,6 +31,7 @@ server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_read_timeout 3600;
         fastcgi_pass unix:VALET_HOME_PATH/valet.sock;
         fastcgi_index VALET_SERVER_PATH;
         include fastcgi_params;


### PR DESCRIPTION
Non secure domains already have a long fastcgi_read_timeout 3600. This change also adds it voor secure domains