### PR TITLE
Add support to switch Elasticsearch version

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -212,4 +212,17 @@ class Brew
             }
         }
     }
+
+    /**
+     * Checks wether the requested services is running.
+     *
+     * @param $formula
+     * @return bool
+     */
+    function isStartedService($formula)
+    {
+        $info = explode(" ", trim(str_replace($formula, "", $this->cli->runAsUser('brew services list | grep ' . $formula))));
+        $state = array_shift($info);
+        return ($state === 'started');
+    }
 }

--- a/cli/Valet/Elasticsearch.php
+++ b/cli/Valet/Elasticsearch.php
@@ -2,10 +2,26 @@
 
 namespace Valet;
 
+use DomainException;
+
 class Elasticsearch
 {
     const NGINX_CONFIGURATION_STUB = __DIR__ . '/../stubs/elasticsearch.conf';
-    CONST NGINX_CONFIGURATION_PATH = '/usr/local/etc/nginx/valet/elasticsearch.conf';
+    const NGINX_CONFIGURATION_PATH = '/usr/local/etc/nginx/valet/elasticsearch.conf';
+
+    const ES_CONFIG_YAML = '/usr/local/etc/elasticsearch/elasticsearch.yml';
+    const ES_CONFIG_DATA_PATH = 'path.data';
+    const ES_CONFIG_DATA_BASEPATH = '/usr/local/var/';
+
+    const ES_FORMULA_NAME = 'elasticsearch@';
+    const ES_V24_VERSION = '2.4';
+    const ES_V56_VERSION = '5.6';
+    const ES_DEFAULT_VERSION = self::ES_V24_VERSION;
+
+    const SUPPORTED_ES_FORMULAE = [
+        self::ES_V24_VERSION => self::ES_FORMULA_NAME . self::ES_V24_VERSION,
+        self::ES_V56_VERSION => self::ES_FORMULA_NAME . self::ES_V56_VERSION,
+    ];
 
     var $brew;
     var $cli;
@@ -16,72 +32,105 @@ class Elasticsearch
     /**
      * Create a new instance.
      *
-     * @param  Brew $brew
-     * @param  CommandLine $cli
-     * @param  Filesystem $files
-     * @param  Configuration $configuration
-     * @param  Site $site
+     * @param Brew          $brew
+     * @param CommandLine   $cli
+     * @param Filesystem    $files
+     * @param Configuration $configuration
+     * @param Site          $site
      */
-    function __construct(Brew $brew, CommandLine $cli, Filesystem $files,
-                         Configuration $configuration, Site $site)
-    {
-        $this->cli = $cli;
-        $this->brew = $brew;
-        $this->site = $site;
-        $this->files = $files;
+    function __construct(
+        Brew $brew,
+        CommandLine $cli,
+        Filesystem $files,
+        Configuration $configuration,
+        Site $site
+    ) {
+        $this->cli           = $cli;
+        $this->brew          = $brew;
+        $this->site          = $site;
+        $this->files         = $files;
         $this->configuration = $configuration;
     }
 
     /**
      * Install the service.
      *
+     * @param string $version
      * @return void
      */
-    function install()
+    function install($version = self::ES_DEFAULT_VERSION)
     {
-        if ($this->installed()) {
-            info('[elasticsearch] already installed');
+        if (!array_key_exists($version, self::SUPPORTED_ES_FORMULAE)) {
+            warning('The Elasticsearch version you\'re installing is not supported.');
+
+            return;
+        }
+
+        if ($this->installed($version)) {
+            info('[' . self::ES_FORMULA_NAME . $version . '] already installed');
+
             return;
         }
 
         $this->cli->quietlyAsUser('brew cask install java');
-        $this->brew->installOrFail('elasticsearch@2.4');
-        $this->restart();
+        $this->brew->installOrFail(self::ES_FORMULA_NAME . $version);
+        $this->restart($version);
     }
 
-    function installed() {
-        return $this->brew->installed('elasticsearch@2.4');
+    /**
+     * Returns wether Elasticsearch is installed.
+     *
+     * @param string $version
+     * @return bool
+     */
+    function installed($version = null)
+    {
+        $versions = ($version ? [$version] : array_keys(self::SUPPORTED_ES_FORMULAE));
+
+        foreach ($versions as $version) {
+            if ($this->brew->installed(self::ES_FORMULA_NAME . $version)) {
+                return $version;
+            }
+        }
+
+        return false;
     }
 
     /**
      * Restart the service.
      *
+     * @param string $version
      * @return void
      */
-    function restart()
+    function restart($version = null)
     {
-        if (!$this->installed()) {
+        $version = ($version ? $version : $this->getCurrentVersion());
+        $version = $this->installed($version);
+        if (!$version) {
             return;
         }
 
-        info('[elasticsearch] Restarting');
-        $this->cli->quietlyAsUser('brew services restart elasticsearch@2.4');
+        info('[' . self::ES_FORMULA_NAME . $version . '] Restarting');
+        $this->cli->quietlyAsUser('brew services restart ' . self::ES_FORMULA_NAME . $version);
     }
 
     /**
      * Stop the service.
      *
+     * @param string $version
      * @return void
      */
-    function stop()
+    function stop($version = null)
     {
-        if (!$this->installed()) {
+        $version = ($version ? $version : $this->getCurrentVersion());
+        $version = $this->installed($version);
+        if (!$version) {
             return;
         }
 
-        info('[elasticsearch] Stopping');
-        $this->cli->quietly('sudo brew services stop elasticsearch@2.4');
-        $this->cli->quietlyAsUser('brew services stop elasticsearch@2.4');
+        info('[' . self::ES_FORMULA_NAME . $version . '] Stopping');
+        $this->cli->quietly('sudo brew services stop ' . self::ES_FORMULA_NAME . $version);
+        $this->cli->quietlyAsUser('brew services stop ' . self::ES_FORMULA_NAME . $version);
     }
 
     /**
@@ -94,6 +143,9 @@ class Elasticsearch
         $this->stop();
     }
 
+    /**
+     * @param $domain
+     */
     function updateDomain($domain)
     {
         $this->files->putAsUser(
@@ -104,5 +156,65 @@ class Elasticsearch
                 $this->files->get(self::NGINX_CONFIGURATION_PATH)
             )
         );
+    }
+
+    /**
+     * Switch between versions of installed Elasticsearch. Switch to the provided version.
+     *
+     * @param $version
+     */
+    function switchTo($version)
+    {
+        $currentVersion = $this->getCurrentVersion();
+
+        if (!array_key_exists($version, self::SUPPORTED_ES_FORMULAE)) {
+            throw new DomainException("This version of Elasticsearch is not supported. The following versions are supported: " . implode(', ', array_keys(self::SUPPORTED_ES_FORMULAE)) . ($currentVersion ? "\nCurrent version is " . $currentVersion : ""));
+        }
+
+
+        // If the current version equals that of the current PHP version, do not switch.
+        if ($version === $currentVersion) {
+            info('Already on this version');
+
+            return;
+        }
+
+        // Make sure the requested version is installed.
+        $installed = $this->brew->installed(self::SUPPORTED_ES_FORMULAE[$version]);
+        if (!$installed) {
+            $this->brew->ensureInstalled(self::SUPPORTED_ES_FORMULAE[$version]);
+        }
+
+        // Stop all versions.
+        $this->stop($currentVersion);
+
+
+        // Alter elasticsearch data path in config yaml.
+        $config                            = yaml_parse_file(self::ES_CONFIG_YAML);
+        $config[self::ES_CONFIG_DATA_PATH] = self::ES_CONFIG_DATA_BASEPATH . self::SUPPORTED_ES_FORMULAE[$version] . '/';
+        yaml_emit_file(self::ES_CONFIG_YAML, $config);
+
+
+        // Start requested version.
+        $this->restart($version);
+
+        info("Valet is now using " . self::SUPPORTED_ES_FORMULAE[$version] . ". You might need to reindex your data.");
+    }
+
+    /**
+     * Returns the current running version.
+     *
+     * @return bool|int|string
+     */
+    function getCurrentVersion()
+    {
+        $currentVersion = false;
+        foreach (self::SUPPORTED_ES_FORMULAE as $version => $formula) {
+            if ($this->brew->isStartedService($formula)) {
+                $currentVersion = $version;
+            }
+        }
+
+        return $currentVersion;
     }
 }

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -14,6 +14,7 @@ class Pecl extends AbstractPecl
     const APCU_BC_EXTENSION = 'apcu_bc';
     const GEOIP_EXTENSION = 'geoip';
     const MEMCACHE_EXTENSION = 'memcached';
+    const YAML_EXTENSION = 'yaml';
 
     // Extension aliases.
     const APCU_BC_ALIAS = 'apc';
@@ -71,6 +72,9 @@ class Pecl extends AbstractPecl
             '7.1' => '3.1.3',
             '7.0' => '3.1.3',
             'default' => false,
+            'extension_type' => self::NORMAL_EXTENSION_TYPE
+        ],
+        self::YAML_EXTENSION => [
             'extension_type' => self::NORMAL_EXTENSION_TYPE
         ]
     ];

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -504,11 +504,31 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Determine if this is the latest version of Valet');
 
     /**
-     * Switch between versions of PHP
+     * Switch between versions of PHP (Default) or Elasticsearch
      */
-    $app->command('use [phpVersion]', function ($phpVersion) {
-        PhpFpm::switchTo($phpVersion);
-    })->descriptions('Switch between versions of PHP');
+    $app->command('use [service] [targetVersion]', function ($service, $targetVersion) {
+        $supportedServices = [
+            'php'           => 'php',
+            'elasticsearch' => 'elasticsearch',
+            'es'            => 'elasticsearch',
+        ];
+        if (is_numeric($service)) {
+            $targetVersion = $service;
+            $service       = 'php';
+        }
+        $service = (isset($supportedServices[$service]) ? $supportedServices[$service] : false);
+
+        switch ($service) {
+            case 'php':
+                PhpFpm::switchTo($targetVersion);
+                break;
+            case 'elasticsearch':
+                Elasticsearch::switchTo($targetVersion);
+                break;
+            default:
+                throw new Exception('Service to switch version of not supported. Supported services: ' . implode(', ', array_unique(array_values($supportedServices))));
+        }
+    })->descriptions('Switch between versions of PHP (default) or Elasticsearch');
 
     /**
      * Create database

--- a/readme.md
+++ b/readme.md
@@ -374,6 +374,20 @@ It will run on the default port `9200`, and is accessible at [http://elasticsear
 
 Elasticsearch 2.4 is installed by default because [Magento 2.1 does not support Elasticsearch 5](http://devdocs.magento.com/guides/v2.1/config-guide/elasticsearch/es-overview.html).
 
+
+### Switching Elasticsearch version
+
+Switch Elasticsearch version using one of these commands:
+
+```
+valet use elasticsearch|es 2.4
+```
+```
+valet use elasticsearch|es 5.6
+```
+
+
+
 ## Framework specific development tools
 
 Valet+ will automatically install framework specific development tools for you:


### PR DESCRIPTION
To support the newer versions of Magento, which also support newer versions of Elasticsearch, I've built the possibility to change Elasticsearch versions. Usefull when you have several projects with different Magento versions.
Currently supported Elasticsearch versions in Valet+ now are 2.4 en 5.6. You can switch between the versions with `valet use elasticsearch|es 2.4|5.6`