### PR TITLE
Load Server Environment Variables in Magento

### DIFF
--- a/cli/drivers/JigsawValetDriver.php
+++ b/cli/drivers/JigsawValetDriver.php
@@ -25,4 +25,18 @@ class JigsawValetDriver extends BasicValetDriver
     {
         return is_dir($sitePath.'/build_local');
     }
+    
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        $this->loadServerEnvironmentVariables($sitePath, $siteName);
+        return parent::frontControllerPath($sitePath, $siteName, $uri);
+    }
 }

--- a/cli/drivers/JoomlaValetDriver.php
+++ b/cli/drivers/JoomlaValetDriver.php
@@ -25,6 +25,8 @@ class JoomlaValetDriver extends BasicValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
+        $this->loadServerEnvironmentVariables($sitePath, $siteName);
+        
         $_SERVER['PHP_SELF'] = $uri;
 
         return parent::frontControllerPath($sitePath, $siteName, $uri);

--- a/cli/drivers/KatanaValetDriver.php
+++ b/cli/drivers/KatanaValetDriver.php
@@ -25,4 +25,18 @@ class KatanaValetDriver extends BasicValetDriver
     {
         return file_exists($sitePath.'/katana');
     }
+    
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        $this->loadServerEnvironmentVariables($sitePath, $siteName);
+        return parent::frontControllerPath($sitePath, $siteName, $uri);
+    }
 }

--- a/cli/drivers/KirbyValetDriver.php
+++ b/cli/drivers/KirbyValetDriver.php
@@ -41,7 +41,8 @@ class KirbyValetDriver extends ValetDriver
      */
     public function frontControllerPath($sitePath, $siteName, $uri)
     {
-
+        $this->loadServerEnvironmentVariables($sitePath, $siteName);
+        
         // Needed to force Kirby to use *.test to generate its URLs...
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 

--- a/cli/drivers/MagentoValetDriver.php
+++ b/cli/drivers/MagentoValetDriver.php
@@ -54,6 +54,6 @@ class MagentoValetDriver extends BasicValetDriver
     {
         $this->loadServerEnvironmentVariables($sitePath, $siteName);
 
-        return $sitePath.'/index.php';
+        return parent::frontControllerPath($sitePath, $siteName, $uri);
     }
 }

--- a/cli/drivers/MagentoValetDriver.php
+++ b/cli/drivers/MagentoValetDriver.php
@@ -41,4 +41,19 @@ class MagentoValetDriver extends BasicValetDriver
 
         info('Configured Magento');
     }
+    
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        $this->loadServerEnvironmentVariables($sitePath, $siteName);
+
+        return $sitePath.'/index.php';
+    }
 }

--- a/cli/drivers/SculpinValetDriver.php
+++ b/cli/drivers/SculpinValetDriver.php
@@ -25,4 +25,18 @@ class SculpinValetDriver extends BasicValetDriver
     {
         return rtrim('/output_dev'.$uri, '/');
     }
+    
+    /**
+     * Get the fully resolved path to the application's front controller.
+     *
+     * @param  string  $sitePath
+     * @param  string  $siteName
+     * @param  string  $uri
+     * @return string
+     */
+    public function frontControllerPath($sitePath, $siteName, $uri)
+    {
+        $this->loadServerEnvironmentVariables($sitePath, $siteName);
+        return parent::frontControllerPath($sitePath, $siteName, $uri);
+    }
 }

--- a/cli/drivers/WordPressMultisiteSubdirectoryValetDriver.php
+++ b/cli/drivers/WordPressMultisiteSubdirectoryValetDriver.php
@@ -37,6 +37,8 @@ class WordPressMultisiteSubdirectoryValetDriver extends BasicValetDriver
         $_SERVER['PHP_SELF']    = $uri;
         $_SERVER['SERVER_ADDR'] = '127.0.0.1';
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+        
+        $this->loadServerEnvironmentVariables($sitePath, $siteName);
 
         // If URI contains one of the main WordPress directories, and it's not a request for the Network Admin,
         // drop the subdirectory segment before routing the request

--- a/cli/drivers/WordPressValetDriver.php
+++ b/cli/drivers/WordPressValetDriver.php
@@ -28,6 +28,8 @@ class WordPressValetDriver extends BasicValetDriver
         $_SERVER['PHP_SELF']    = $uri;
         $_SERVER['SERVER_ADDR'] = '127.0.0.1';
         $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+        
+        $this->loadServerEnvironmentVariables($sitePath, $siteName);
 
         return parent::frontControllerPath(
             $sitePath, $siteName, $this->forceTrailingSlash($uri)


### PR DESCRIPTION
Looks like this was missed in error when the feature was added to the other drivers https://github.com/weprovide/valet-plus/commit/5038391c26ef07b4d31976882d7710d66dd5c012

Probably just because the `frontControllerPath` method wasn't overridden in this driver so wouldn't have show up in a grep