### PR TITLE
Fix Shopware5 Driver to be updater compatible

### DIFF
--- a/cli/drivers/Shopware5ValetDriver.php
+++ b/cli/drivers/Shopware5ValetDriver.php
@@ -57,6 +57,15 @@ class Shopware5ValetDriver extends ValetDriver
             return $installPath;
         }
 
+        if ($this->isUpdaterPath($sitePath, $uri)) {
+	    $updaterPath = $this->buildUpdaterPath($sitePath, $uri);
+            $_SERVER['SCRIPT_FILENAME'] = $updaterPath;
+            $_SERVER['SCRIPT_NAME'] = str_replace($sitePath, '', $updaterPath);
+            $_SERVER['DOCUMENT_ROOT'] = $sitePath;
+
+            return $updaterPath;
+        }
+
         return $sitePath . '/shopware.php';
     }
 
@@ -72,6 +81,18 @@ class Shopware5ValetDriver extends ValetDriver
         return (strpos($uri, 'recovery/install') !== false);
     }
 
+    /**
+     * check if uri contains shopware update path
+     *
+     * @param string $sitePath
+     * @param string $uri
+     * @return bool
+     */
+    protected function isUpdaterPath($sitePath, $uri)
+    {
+        return (strpos($uri, 'recovery/update') !== false);
+    }
+
 
     /**
      * build shopware install url
@@ -83,5 +104,17 @@ class Shopware5ValetDriver extends ValetDriver
     protected function buildInstallPath($sitePath, $uri)
     {
         return $sitePath . '/recovery/install/index.php';
+    }
+
+    /**
+     * build shopware install url
+     *
+     * @param $sitePath
+     * @param $uri
+     * @return string
+     */
+    protected function buildUpdaterPath($sitePath, $uri)
+    {
+        return $sitePath . '/recovery/update/index.php';
     }
 }


### PR DESCRIPTION
Currently you are not able to use the auto updater of Shopware5. This might not always be relevant but is still easy to fix. That allows some 'not into git' people to be able to update Shopware5 to any new version (except the shopware platform ;) )