### PR TITLE
Load server environment variables for static files

### DIFF
--- a/cli/drivers/Magento2ValetDriver.php
+++ b/cli/drivers/Magento2ValetDriver.php
@@ -77,6 +77,7 @@ class Magento2ValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
+        $this->loadServerEnvironmentVariables($sitePath, $siteName);
         $isMagentoStatic = false;
         $resource = $uri;
         


### PR DESCRIPTION
In Magento 2 we use environment variables for config settings
We get the error

```
Fatal error: Uncaught Zend_Cache_Exception: Redis 'server' not specified. in /magento2/src/vendor/magento/zendframework1/library/Zend/Cache.php:209 Stack trace: 
#0 /magento2/src/vendor/colinmollenhour/cache-backend-redis/Cm/Cache/Backend/Redis.php(147): Zend_Cache::throwException('Redis 'server' ...') 
#1 /magento2/src/vendor/magento/zendframework1/library/Zend/Cache.php(153): Cm_Cache_Backend_Redis->__construct(Array) 
#2 /magento2/src/vendor/magento/zendframework1/library/Zend/Cache.php(94): Zend_Cache::_makeBackend('Cm_Cache_Backen...', Array, true, true) 
#3 /magento2/src/vendor/magento/framework/App/Cache/Frontend/Factory.php(156): Zend_Cache::factory('Magento\\Framewo...', 'Cm_Cache_Backen...', Array, Array, true, true, true) 
#4 /magento2/src/vendor/magento/framework/Cache/Frontend/Adapter/Zend.php(38): Magento\Framewo in /magento2/src/vendor/magento/zendframework1/library/Zend/Cache.php on line 209
```
The reason is the method does not load the environment variables
This PR will fix that 