### PR TITLE
Fix APCU_BC pecl extension generating errors upon install

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,12 @@
+UPGRADE FROM 1.0.x to 2.0
+=======================
+
+### APCU_BC install
+
+  * Due to issues with the `apcu_bc` pecl extension install and [growing support for PHP 7.0+](https://pecl.php.net/package/APCu)
+  within the `apcu` pecl extension, deprecate the use of `apcu_bc`. To ensure new `apcu` install
+  do the following for every PHP version installed:
+
+      * Uninstall your pecl installed apcu extensions `pecl uninstall apcu && pecl uninstall apcu_bc`
+
+      * Remove the `apcu.so` and `apc.so` extensions from `/usr/local/etc/valet-php/<version>/php.ini`

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -47,15 +47,11 @@ class Pecl extends AbstractPecl
             'default' => false,
             'extension_type' => self::ZEND_EXTENSION_TYPE
         ],
-        self::APCU_BC_EXTENSION => [
-            '5.6' => false,
-            'extension_type' => self::NORMAL_EXTENSION_TYPE
-        ],
         self::APCU_EXTENSION => [
-            '7.3' => false,
-            '7.2' => false,
-            '7.1' => false,
-            '7.0' => false,
+            '7.3' => '5.1.17',
+            '7.2' => '5.1.17',
+            '7.1' => '5.1.17',
+            '7.0' => '5.1.17',
             '5.6' => '4.0.11',
             'extension_type' => self::NORMAL_EXTENSION_TYPE
         ],
@@ -263,9 +259,6 @@ class Pecl extends AbstractPecl
     private function alternativeDisable($extension)
     {
         switch ($extension) {
-            case self::APCU_BC_EXTENSION:
-                $this->disable(self::APCU_EXTENSION);
-                break;
             default:
                 break;
         }
@@ -283,10 +276,6 @@ class Pecl extends AbstractPecl
     private function alternativeUninstall($extension)
     {
         switch ($extension) {
-            case self::APCU_BC_EXTENSION:
-                $version = $this->getVersion($extension);
-                $this->uninstall(self::APCU_EXTENSION, $version);
-                break;
             default:
                 break;
         }
@@ -460,8 +449,6 @@ class Pecl extends AbstractPecl
     private function alternativeInstall($extension, $phpIniFile)
     {
         switch ($extension) {
-            case self::APCU_BC_EXTENSION:
-                return $this->replaceIniDefinition(self::APCU_EXTENSION, $phpIniFile);
             default:
                 return $phpIniFile;
         }
@@ -511,8 +498,6 @@ class Pecl extends AbstractPecl
     protected function getExtensionAlias($extension)
     {
         switch ($extension) {
-            case self::APCU_BC_EXTENSION:
-                return self::APCU_BC_ALIAS;
             default:
                 return $extension;
         }
@@ -562,8 +547,6 @@ class Pecl extends AbstractPecl
      */
     private function isAlternativeEnabledCorrectly($extension){
         switch ($extension) {
-            case self::APCU_BC_EXTENSION:
-                return $this->isEnabledCorrectly(self::APCU_EXTENSION);
             default:
                 return true;
         }


### PR DESCRIPTION
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
- [X] I have created an issue which accompanies my PR: https://github.com/weprovide/valet-plus/issues/393.

**I have read the contribution guidelines and am targeting the branch `2.x` because:**  
Because this is a Bug fix which is not backwards compatible.

**Changelog entry:**  
Fixed installation bug with `apcu_bc` due to double `.so` directives getting placed in php.ini