### PR TITLE
Add ioncube for php 7.3

### DIFF
--- a/cli/Valet/PeclCustom.php
+++ b/cli/Valet/PeclCustom.php
@@ -52,6 +52,7 @@ class PeclCustom extends AbstractPecl
      */
     const EXTENSIONS = [
         self::IONCUBE_LOADER_EXTENSION => [
+            '7.3' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
             '7.2' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
             '7.1' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
             '7.0' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',


### PR DESCRIPTION
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
- [X] I have created an issue which accompanies my PR: https://github.com/weprovide/valet-plus/issues/393.

**I have read the contribution guidelines and am targeting the branch `2.x` because:**  
Because this is a Bug fix which is backwards compatible.

**Changelog entry:**  
Fixed installation bug with `ioncube` due to PHP 7.3 not being configured.