### PR TITLE
Always suffix Elasticsearch version in datapath #407

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -385,6 +385,9 @@ valet use elasticsearch|es 2.4
 ```
 valet use elasticsearch|es 5.6
 ```
+```
+valet use elasticsearch|es 6.8
+```
 
 
 


### PR DESCRIPTION
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
- [X] I have created an issue which accompanies my PR: https://github.com/weprovide/valet-plus/issues/407.

**I have read the contribution guidelines and am targeting the branch `2.x` because:**  
Because this is a Bug fix which is backwards compatible.

**Changelog entry:**  
- Fixed installation bug with Elasticsearch  due to PECL `yaml` not being installed.
- Fixed switching Elasticsearch bug by always suffixing the version in the datapath config.