### PR TITLE
Fix SUBDOMAIN_INSTALL check in WordPress subdirectory driver

### DIFF
--- a/cli/drivers/WordPressMultisiteSubdirectoryValetDriver.php
+++ b/cli/drivers/WordPressMultisiteSubdirectoryValetDriver.php
@@ -17,9 +17,9 @@ class WordPressMultisiteSubdirectoryValetDriver extends BasicValetDriver
         return file_exists($sitePath . '/wp-config.php') && 
         (strpos( file_get_contents($sitePath . '/wp-config.php'), 'MULTISITE') !== false) &&
         (
-            //Double check if we are using subdomains.
-            strpos( file_get_contents($sitePath . '/wp-config.php'), "define('SUBDOMAIN_INSTALL',true)") || 
-            strpos( file_get_contents($sitePath . '/wp-config.php'), "define('SUBDOMAIN_INSTALL', true)")
+            // Double check if we are using subdomains. SUBDOMAIN_INSTALL is false by default.
+            // If it has not been set as true, then this is a subdirectory configuration.
+            ! preg_match('/define[(]\s?\'SUBDOMAIN_INSTALL\'\s?,\s?true\s?[)];/i', file_get_contents($sitePath . '/wp-config.php') )
         );
         
     }


### PR DESCRIPTION
WordPress assumes subdirectory mode if the `MULTISITE` constant is defined and either (a) there is no `SUBDOMAIN_INSTALL` constant defined in `wp-config.php` or (b) `SUBDOMAIN_INSTALL` is defined as `false` in `wp-config.php`.

To properly check `wp-config.php` by parsing the configuration, we should assume a subdirectory install only if it is *not* defined as `true`. The current driver looks for `true` instead, which means that the driver is only used in a subdomain configuration.

This PR adds a `! preg_match()` check accounting for the various types of spacing that may be used in the config when `SUBDOMAIN_INSTALL` is set to `true`.

Fixes #429 with a different approach from #430.