### PR TITLE
Fix 'valet links' - get length of .crt.tld dynamically

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -83,10 +83,12 @@ class Site
      */
     function getCertificates($path)
     {
+        $config = $this->config->read();
+        $len = 5 + strlen($config['domain']);
         return collect($this->files->scanDir($path))->filter(function ($value, $key) {
             return ends_with($value, '.crt');
-        })->map(function ($cert) {
-            return substr($cert, 0, -8);
+        })->map(function ($cert) use ($len) {
+            return substr($cert, 0, -$len);
         })->flip();
     }
 


### PR DESCRIPTION
'valet links' command relies on `getCertificates()`, which checks for certificate files. `getCertificates()` returns the names of the certificates it finds with the '.crt.tld' part stripped, except that it always strips 8 characters from strings, which only works if the domain you're using is 3 characters long ('dev', 'tld', etc). This results in `valet links` displaying secured sites as non-secure - with 'http' instead of 'https' and with no 'X' in the 'SSL' column.
This fix gets the length of the domain that's currently being used (ex. 'test'), and strips the appropriate amount of characters from the certificate name. This, in turn, fixes the `valet links` command, which now displays an 'X' in the 'SSL' column, and prepends secure site URLs with 'https' as expected.