### PR TITLE
Fix MySQL not being linked upon install

### DIFF
--- a/cli/Valet/Mysql.php
+++ b/cli/Valet/Mysql.php
@@ -72,6 +72,13 @@ class Mysql
         $this->stop();
         $this->installConfiguration($type);
         $this->restart();
+
+        // If formula is versioned link the formula as the binary.
+        if (strpos($type, '@')) {
+            $this->cli->runAsUser("brew link $type --force", function () {
+                warning('Failed linking MySQL!');
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
- [X] I have created an issue which accompanies my PR: https://github.com/weprovide/valet-plus/issues/411.

**I have read the contribution guidelines and am targeting the branch `2.x`:**  
Because this is a Bug Fix which is Backwards Compatible.

**Changelog entry:**  
Short description of your work as explained by: [Keep A Changelog](https://keepachangelog.com).

- Fixed versioned MySQL (E.G: MySQL@5.7) not being linked upon install.