### PR TITLE
Fix PHP 7.0 installation wrong xdebug version

### DIFF
--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -43,6 +43,7 @@ class Pecl extends AbstractPecl
      */
     const EXTENSIONS = [
         self::XDEBUG_EXTENSION => [
+            '7.0' => '2.9.0',
             '5.6' => '2.2.7',
             'default' => false,
             'extension_type' => self::ZEND_EXTENSION_TYPE


### PR DESCRIPTION
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
- [X] I have created an issue which accompanies my PR: https://github.com/weprovide/valet-plus/issues/448.

**I have read the contribution guidelines and am targeting the branch `2.x`:**  
Because this is a Bug Fix which is Backwards Compatible.

**Changelog entry:**  
Short description of your work as explained by: [Keep A Changelog](https://keepachangelog.com).

- Fixed xdebug not installing on PHP version 7.0 due to new xdebug version which only supports PHP 7.1+