### PR TITLE
Fix switching php versions not listening to error states

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -175,18 +175,83 @@ class PhpFpm
             $this->brew->ensureInstalled(self::SUPPORTED_PHP_FORMULAE[$version]);
         }
 
-        info("[php@$currentVersion] Unlinking");
-        output($this->cli->runAsUser('brew unlink ' . self::SUPPORTED_PHP_FORMULAE[$currentVersion]));
+        // Unlink the current PHP version.
+        if (!$this->unlinkPhp($currentVersion)) {
+            return;
+        }
 
+        // Relink libjpeg
         info('[libjpeg] Relinking');
         $this->cli->passthru('sudo ln -fs /usr/local/Cellar/jpeg/8d/lib/libjpeg.8.dylib /usr/local/opt/jpeg/lib/libjpeg.8.dylib');
 
-        info("[php@$version] Linking");
-        output($this->cli->runAsUser('brew link ' . self::SUPPORTED_PHP_FORMULAE[$version] . ' --force --overwrite'));
+        if (!$this->linkPHP($version, $currentVersion)) {
+            return;
+        }
 
         $this->stop();
         $this->install();
         info("Valet is now using " . self::SUPPORTED_PHP_FORMULAE[$version]);
+    }
+
+    /**
+     * Link a PHP version to be used as binary.
+     *
+     * @param $version
+     *
+     * @return bool
+     */
+    private function linkPhp($version, $currentVersion = null)
+    {
+        $isLinked = true;
+        info("[php@$version] Linking");
+        $output = $this->cli->runAsUser('brew link ' . self::SUPPORTED_PHP_FORMULAE[$version] . ' --force --overwrite', function () use (&$isLinked) {
+            $isLinked = false;
+        });
+
+        // If the output is about how many symlinks were created.
+        // Sanitize the second half to prevent users from being confused.
+        // So the only ouput would be:
+        // Linking /usr/local/Cellar/valet-php@7.3/7.3.8... 25 symlinks created
+        // Without the directions to create exports pointing towards the binaries.
+        if (strpos($output, 'symlinks created')) {
+            $output = substr($output, 0, strpos($output, 'symlinks created') + 8);
+        }
+        output($output);
+
+        if ($isLinked === false) {
+            warning("Could not link PHP version!" . PHP_EOL .
+                "There appears to be an issue with your PHP $version installation!" . PHP_EOL .
+                "See the output above for more information." . PHP_EOL);
+        }
+
+        if ($currentVersion !== null && $isLinked === false) {
+            info("Linking back to previous version to prevent broken installation!");
+            $this->linkPhp($currentVersion);
+        }
+
+        return $isLinked;
+    }
+
+    /**
+     * Unlink a PHP version, removing the binary symlink.
+     *
+     * @param $version
+     * @return bool
+     */
+    private function unlinkPhp($version)
+    {
+        $isUnlinked = true;
+        info("[php@$version] Unlinking");
+        output($this->cli->runAsUser('brew unlink ' . self::SUPPORTED_PHP_FORMULAE[$version], function () use (&$isUnlinked) {
+            $isUnlinked = false;
+        }));
+        if ($isUnlinked === false) {
+            warning("Could not unlink PHP version!" . PHP_EOL .
+                "There appears to be an issue with your PHP $version installation!" . PHP_EOL .
+                "See the output above for more information.");
+        }
+
+        return $isUnlinked;
     }
 
     /**

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -197,7 +197,7 @@ class PhpFpm
      * Link a PHP version to be used as binary.
      *
      * @param $version
-     *
+     * @param $currentVersion
      * @return bool
      */
     private function linkPhp($version, $currentVersion = null)

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -208,7 +208,7 @@ class PhpFpm
             $isLinked = false;
         });
 
-        // If the output is about how many symlinks were created.
+        // The output is about how many symlinks were created.
         // Sanitize the second half to prevent users from being confused.
         // So the only output would be:
         // Linking /usr/local/Cellar/valet-php@7.3/7.3.8... 25 symlinks created

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -210,7 +210,7 @@ class PhpFpm
 
         // If the output is about how many symlinks were created.
         // Sanitize the second half to prevent users from being confused.
-        // So the only ouput would be:
+        // So the only output would be:
         // Linking /usr/local/Cellar/valet-php@7.3/7.3.8... 25 symlinks created
         // Without the directions to create exports pointing towards the binaries.
         if (strpos($output, 'symlinks created')) {


### PR DESCRIPTION
- [X] There is an issue ticket which accompanies my PR: https://github.com/weprovide/valet-plus/issues/451.
- [X] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [X] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `2.x`:**  
Because this is a Bug Fix which is Backwards Compatible.  

**Changelog entry:**  
Short description of your work as explained by: [Keep A Changelog](https://keepachangelog.com).

- Fixed bug where switching PHP version to a flawed installation would result in an unusable valet-plus installation.
