### PR TITLE
Add support for ElasticSearch 7.6

### DIFF
--- a/cli/Valet/Elasticsearch.php
+++ b/cli/Valet/Elasticsearch.php
@@ -17,12 +17,14 @@ class Elasticsearch
     const ES_V24_VERSION     = '2.4';
     const ES_V56_VERSION     = '5.6';
     const ES_V68_VERSION     = '6.8';
+    const ES_V76_VERSION     = '7.6';
     const ES_DEFAULT_VERSION = self::ES_V24_VERSION;
 
     const SUPPORTED_ES_FORMULAE = [
         self::ES_V24_VERSION => self::ES_FORMULA_NAME . '@' . self::ES_V24_VERSION,
         self::ES_V56_VERSION => self::ES_FORMULA_NAME . '@' . self::ES_V56_VERSION,
-        self::ES_V68_VERSION => self::ES_FORMULA_NAME,
+        self::ES_V68_VERSION => self::ES_FORMULA_NAME . '@' . self::ES_V68_VERSION,
+        self::ES_V76_VERSION => self::ES_FORMULA_NAME . '@' . self::ES_V76_VERSION,
     ];
 
     public $brew;


### PR DESCRIPTION
This PR adds support for ElasticSearch 7.6 to Valet+.

- [x] There is an issue ticket which accompanies my PR: #496 
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `2.x`
Because this is a Feature which is Backwards Compatible.  

**Changelog entry:**  
- Added support for ElasticSearch 7.6