### PR TITLE
[TASK] Mysql 5.7 fix for Unknown table column_statistics mysqldump error

### DIFF
--- a/cli/stubs/my.cnf
+++ b/cli/stubs/my.cnf
@@ -3,6 +3,9 @@ user=root
 password=root
 host=localhost
 
+[mysqldump]
+column-statistics=0
+
 [mysqld]
 sql_mode="NO_ENGINE_SUBSTITUTION"
 innodb_file_per_table=OFF


### PR DESCRIPTION
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `2.x`:**  
Because this is a Bugfix which is Backwards Compatible.  

**Changelog entry:**  
Short description of your work as explained by: [Keep A Changelog](https://keepachangelog.com).
### Added
- Mysql 5.7 fix for Unknown table column_statistics mysqldump error