### PR TITLE
Change default ES version to v6.8

### DIFF
--- a/cli/Valet/Elasticsearch.php
+++ b/cli/Valet/Elasticsearch.php
@@ -18,7 +18,7 @@ class Elasticsearch
     const ES_V56_VERSION     = '5.6';
     const ES_V68_VERSION     = '6.8';
     const ES_V76_VERSION     = '7.6';
-    const ES_DEFAULT_VERSION = self::ES_V24_VERSION;
+    const ES_DEFAULT_VERSION = self::ES_V68_VERSION;
 
     const SUPPORTED_ES_FORMULAE = [
         self::ES_V24_VERSION => self::ES_FORMULA_NAME . '@' . self::ES_V24_VERSION,


### PR DESCRIPTION
v2.4, the previous default, has not been supported on Magento in a _long_ time. Though ES v7.x.x is [now the default on Magento](https://devdocs.magento.com/guides/v2.3/config-guide/elasticsearch/es-overview.html#es-spt-versions), that only happened as of Magento v2.3.5 (released 4/28/20). ES v6.8.x remains supported and ensures Valet+ has the greatest range of support out of the box.

- [x] There is an issue ticket which accompanies my PR: #494
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `v2.x`:**  
Because this is a Bug Fix which is Backwards Compatible.  

**Changelog entry:**  
Change default Elasticsearch version to v6.8
