### PR TITLE
Use SHA265 for generating self signed certificates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,3 +3,12 @@
 - [ ] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
 - [ ] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
 -----
+
+**I have read the contribution guidelines and am targeting the branch `<YOUR_TARGET_BRANCH>`:**  
+Because this is a Bug Fix which is Backwards Compatible.  
+Because this is a Feature which is not Backwards Compatible.  
+Because this is a Deprecation which is Backwards Compatible.  
+etc...
+
+**Changelog entry:**  
+Short description of your work as explained by: [Keep A Changelog](https://keepachangelog.com).

--- a/cli/Valet/Elasticsearch.php
+++ b/cli/Valet/Elasticsearch.php
@@ -155,16 +155,14 @@ class Elasticsearch
      */
     public function updateDomain($domain)
     {
-        if ($this->files->exists(self::NGINX_CONFIGURATION_PATH)) {
-            $this->files->putAsUser(
-                self::NGINX_CONFIGURATION_PATH,
-                str_replace(
-                    ['VALET_DOMAIN'],
-                    [$domain],
-                    $this->files->get(self::NGINX_CONFIGURATION_PATH)
-                )
-            );
-        }
+        $this->files->putAsUser(
+            self::NGINX_CONFIGURATION_PATH,
+            str_replace(
+                ['VALET_DOMAIN'],
+                [$domain],
+                $this->files->get(self::NGINX_CONFIGURATION_STUB)
+            )
+        );
     }
 
     /**

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -273,7 +273,7 @@ class Site
         $this->createSigningRequest($url, $keyPath, $csrPath, $confPath);
 
         $this->cli->runAsUser(sprintf(
-            'openssl x509 -req -days 365 -in %s -signkey %s -out %s -extensions v3_req -extfile %s',
+            'openssl x509 -req -sha256 -days 365 -in %s -signkey %s -out %s -extensions v3_req -extfile %s',
             $csrPath,
             $keyPath,
             $crtPath,
@@ -303,7 +303,7 @@ class Site
     public function createSigningRequest($url, $keyPath, $csrPath, $confPath)
     {
         $this->cli->runAsUser(sprintf(
-            'openssl req -new -key %s -out %s -subj "/C=/ST=/O=/localityName=/commonName=*.%s/organizationalUnitName=/emailAddress=/" -config %s -passin pass:',
+            'openssl req -new -sha256 -key %s -out %s -subj "/C=/ST=/O=/localityName=/commonName=*.%s/organizationalUnitName=/emailAddress=/" -config %s -passin pass:',
             $keyPath,
             $csrPath,
             $url,

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This project is a fork of [laravel/valet](https://github.com/laravel/valet). Tha
 
 ## Valet+ Authors
 
-- MischaBraam (@mischa Valet+ slack channel)
+- Mischa Braam (@mischa Valet+ slack channel)
 - Tim Neutkens ([@timneutkens](https://github.com/timneutkens))
 - Lou van der Laarse ([@Neodork](https://github.com/Neodork))
 - Sam Granger ([@samgranger](https://github.com/samgranger))

--- a/readme.md
+++ b/readme.md
@@ -15,12 +15,14 @@ This project is a fork of [laravel/valet](https://github.com/laravel/valet). Tha
 
 ## Valet+ Authors
 
-- Mischa Braam ([@mischabraam](https://github.com/mischabraam))
 - Tim Neutkens ([@timneutkens](https://github.com/timneutkens))
-- Lou van der Laarse ([@Neodork](https://github.com/Neodork))
 - Sam Granger ([@samgranger](https://github.com/samgranger))
-- Sander Pott (@sander Valet+ slack channel)
 
+## Valet+ Contributors
+
+- Lou van der Laarse ([@Neodork](https://github.com/Neodork))
+- Sander Pott (@Sander Valet+ slack channel)
+- Mischa Braam ([@mischabraam](https://github.com/mischabraam))
 
 ## Get in touch
 

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ This project is a fork of [laravel/valet](https://github.com/laravel/valet). Tha
 - Tim Neutkens ([@timneutkens](https://github.com/timneutkens))
 - Lou van der Laarse ([@Neodork](https://github.com/Neodork))
 - Sam Granger ([@samgranger](https://github.com/samgranger))
+- Sander (@sander Valet+ slack channel)
 
 
 ## Get in touch
@@ -25,3 +26,5 @@ This project is a fork of [laravel/valet](https://github.com/laravel/valet). Tha
 [![slack](https://p9.zdassets.com/hc/theme_assets/138842/200037786/logo.png)](https://join.slack.com/t/valet-plus/shared_invite/enQtNDE2MjU2NzgyNjQwLWFiYWNjOWFhOWQ2ZDcyOTEyZTA2MzAzOWYyYzYwMTYzODVlMGE3ZDg3ZWQ1M2JmN2M0OGY3OGUwMDI3NDM1NDU)
 
 We have a slack workspace available [which you can join](https://join.slack.com/t/valet-plus/shared_invite/enQtNDE2MjU2NzgyNjQwLWFiYWNjOWFhOWQ2ZDcyOTEyZTA2MzAzOWYyYzYwMTYzODVlMGE3ZDg3ZWQ1M2JmN2M0OGY3OGUwMDI3NDM1NDU).
+
+Yes, we have a Valet+ fan page https://www.weprovide.com/valet-plus

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ This project is a fork of [laravel/valet](https://github.com/laravel/valet). Tha
 
 ## Valet+ Authors
 
-- Mischa Braam (@mischa Valet+ slack channel)
+- Mischa Braam ([@mischabraam](https://github.com/mischabraam))
 - Tim Neutkens ([@timneutkens](https://github.com/timneutkens))
 - Lou van der Laarse ([@Neodork](https://github.com/Neodork))
 - Sam Granger ([@samgranger](https://github.com/samgranger))

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ This project is a fork of [laravel/valet](https://github.com/laravel/valet). Tha
 
 ## Valet+ Authors
 
+- MischaBraam (@mischa Valet+ slack channel)
 - Tim Neutkens ([@timneutkens](https://github.com/timneutkens))
 - Lou van der Laarse ([@Neodork](https://github.com/Neodork))
 - Sam Granger ([@samgranger](https://github.com/samgranger))

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ This project is a fork of [laravel/valet](https://github.com/laravel/valet). Tha
 - Tim Neutkens ([@timneutkens](https://github.com/timneutkens))
 - Lou van der Laarse ([@Neodork](https://github.com/Neodork))
 - Sam Granger ([@samgranger](https://github.com/samgranger))
-- Sander (@sander Valet+ slack channel)
+- Sander Pott (@sander Valet+ slack channel)
 
 
 ## Get in touch


### PR DESCRIPTION
- [x] There is an issue ticket which accompanies my PR: https://github.com/weprovide/valet-plus/issues/520
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `2.x`:**  
Because this is a Bug Fix which is Backwards Compatible. 
Should be backwards compatible as it is an additional option to openssl.
Rest of the code should not be affected
Changed to 2.x branch because build does not work for PHP5.6

**Changelog entry:**  
Add to the openssl command that it should use the sha265 encryption