### PR TITLE
Fix symfony/polyfill-php80 being required by new version of symfony/debug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "nategood/httpful": "~0.2",
         "tightenco/collect": "~5.4.0",
         "sebastian/version": "^2.0",
-        "squizlabs/php_codesniffer": "*"
+        "squizlabs/php_codesniffer": "*",
+        "symfony/debug": "4.4.8"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",


### PR DESCRIPTION
- [X] There is an issue ticket which accompanies my PR: https://github.com/weprovide/valet-plus/issues/527.
- [X] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [X] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `<YOUR_TARGET_BRANCH>`:**  
Because this is a Bug Fix which is Backwards Compatible.  

**Changelog entry:**  
Fixed syntax error due to symfony/polyfill-php80 being required by new version (4.4.9) of symfony/debug