### PR TITLE
Deprecate old PHP fixes for old brew formulae

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -39,8 +39,6 @@ if (is_dir(VALET_HOME_PATH)) {
  * Allow Valet to be run more conveniently by allowing the Node proxy to run password-less sudo.
  */
 $app->command('install [--with-mariadb]', function ($withMariadb) {
-    PhpFpm::checkInstallation();
-
     Nginx::stop();
     PhpFpm::stop();
     Mysql::stop();


### PR DESCRIPTION
- [X] There is an issue ticket which accompanies my PR: https://github.com/weprovide/valet-plus/issues/534.
- [X] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [X] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `2.x`:**  
Because this is a Deprecation which is Backwards Compatible.  

**Changelog entry:**  
- Deprecate old PHP fixes within `valet fix` for old brew formulae now replaced by henkrehost/php