### PR TITLE
Fix valet fix forcefully reinstalling and relinking the default PHP version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
     displayName: '[INSTALL] Brew update'
 
   # For the Valet+ CI/CD remove the default brew PHP. Instead use valet-php.
-  # An enduser might choose to keep his/her default brew PHP installation.
+  # On a local installation one might choose to keep his/her default brew PHP installation.
   - script: |
       brew uninstall php
     displayName: '[INSTALL] Brew uninstall php'
@@ -184,3 +184,14 @@ steps:
   - script: |
       ./valet memcache uninstall
     displayName: '[MEMCACHED] uninstall'
+
+  # Extensions of commonly run commands, generally not hit or checked by the installation instructions.
+
+  # Chown the default PHP version to ensure deletion is possible.
+  # If we don't chown we'll get an permission error from the CI/CD.
+  # On local installations the printed instructions can be followed
+  # to manually remove the Cellar files.
+  - script: |
+      sudo chmod -R 777 /usr/local/Cellar/valet-php@7.2
+      ./valet fix --reinstall
+    displayName: '[INSTALL] Valet fix --reinstall'

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -470,11 +470,22 @@ class PhpFpm
     public function fix($reinstall)
     {
         // If the current php is not 7.2, link 7.2.
-        info('Installing and linking new PHP homebrew/core version.');
-        output($this->cli->runAsUser('brew uninstall ' . self::SUPPORTED_PHP_FORMULAE[self::PHP_V72_VERSION]));
-        output($this->cli->runAsUser('brew install ' . self::SUPPORTED_PHP_FORMULAE[self::PHP_V72_VERSION]));
-        output($this->cli->runAsUser('brew unlink ' . self::SUPPORTED_PHP_FORMULAE[self::PHP_V72_VERSION]));
-        output($this->cli->runAsUser('brew link ' . self::SUPPORTED_PHP_FORMULAE[self::PHP_V72_VERSION] . ' --force --overwrite'));
+        info('Check Valet+ PHP version...');
+        info('Run valet fix with the --reinstall option to trigger a full reinstall of the default PHP version.');
+
+        // If the reinstall flag was passed, uninstall PHP.
+        // If any error occurs return the error for debugging purposes.
+        if ($reinstall) {
+            $this->brew->ensureUninstalled(self::SUPPORTED_PHP_FORMULAE[self::PHP_V72_VERSION]);
+            $this->brew->ensureInstalled(self::SUPPORTED_PHP_FORMULAE[self::PHP_V72_VERSION]);
+        }
+
+        // Check the current linked PHP version. If the current version is not the default version.
+        // Then relink the default version.
+        if ($this->linkedPhp() !== self::PHP_V72_VERSION) {
+            $this->unlinkPhp(self::PHP_V72_VERSION);
+            $this->linkPhp(self::PHP_V72_VERSION);
+        }
 
         // Untap the deprecated brew tap.
         if ($this->brew->hasTap(self::DEPRECATED_PHP_TAP)) {


### PR DESCRIPTION
- [X] There is an issue ticket which accompanies my PR: https://github.com/weprovide/valet-plus/issues/536.
- [X] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [X] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `2.x`:**  
Because this is a Bug Fix which is Backwards Compatible.  

**Changelog entry:**  
- Fixed `valet fix` forcefully trying to reinstall and relink the default PHP version. Even when not on the default version. Causing a faulty link process (overwriting).