### PR TITLE
Fix for Brew 2.7.0: brew list command without arguments is deprecated

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -30,7 +30,7 @@ class Brew
      */
     public function installed($formula)
     {
-        return in_array($formula, explode(PHP_EOL, $this->cli->runAsUser('brew list | grep ' . $formula)));
+        return in_array($formula, explode(PHP_EOL, $this->cli->runAsUser('brew list --formula | grep ' . $formula)));
     }
 
     /**


### PR DESCRIPTION
This issues caused a complete mallfunction of Valet plus after updating my brew to version: 2.7.0

This issues prevents Valet plus from starting services and installing packages.

- [x] There is an issue ticket which accompanies my PR: https://github.com/weprovide/valet-plus/issues/553