### PR TITLE
Fix valet-php@7.2 not being able to be installed due to symlink error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,8 +33,10 @@ steps:
       brew tap henkrehorst/php
     displayName: '[INSTALL] Brew tap henkrehost/php'
 
+  # Remove 2to3 to ensure python installation: https://github.com/weprovide/valet-plus/issues/558
   # Install the default PHP version (currently: valet-php@7.2).
   - script: |
+      rm /usr/local/bin/2to3
       brew install valet-php@7.2
     displayName: '[INSTALL] Brew install valet-php@7.2'
 


### PR DESCRIPTION
- [X] There is an issue ticket which accompanies my PR: https://github.com/weprovide/valet-plus/issues/558.
- [X] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [X] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `<YOUR_TARGET_BRANCH>`:**  
Because this is a Bug Fix which is Backwards Compatible.  

**Changelog entry:**  
Short description of your work as explained by: [Keep A Changelog](https://keepachangelog.com).
- Fixed python installation symlink bug (2to3) preventing valet-php@7.2 to install
