### PR TITLE
Use PHP 7.2 as default on install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/weprovide/valet-plus/compare/2.1.0...2.x)
+- Use PHP as default version
 
 ## [2.1.0](https://github.com/weprovide/valet-plus/compare/2.0.0...2.1.0)
 ## Removed

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -64,7 +64,7 @@ class PhpFpm
     public function install()
     {
         if (!$this->hasInstalledPhp()) {
-            $this->brew->ensureInstalled($this->getFormulaName(self::PHP_V71_VERSION));
+            $this->brew->ensureInstalled($this->getFormulaName(self::PHP_V72_VERSION));
         }
 
         if (!$this->brew->hasTap(self::VALET_PHP_BREW_TAP)) {


### PR DESCRIPTION
- [ ] There is an issue ticket which accompanies my PR: <Your-Issue-Link>.
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `<YOUR_TARGET_BRANCH>`:**  
Because this is a Bug Fix which is Backwards Compatible.  
Because this is a Feature which is not Backwards Compatible.  
Because this is a Deprecation which is Backwards Compatible.  
etc...

**Changelog entry:**  
Use PHP 7.2 on install