### PR TITLE
Add support for /usr/localSudoers entries have been added for Brew an…

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -268,4 +268,28 @@ class Brew
 
         return $versions;
     }
+
+
+    /**
+     * Create the "sudoers.d" entry for running Brew.
+     *
+     * @return void
+     */
+    public function createSudoersEntry()
+    {
+        $this->files->ensureDirExists('/etc/sudoers.d');
+
+        $this->files->put('/etc/sudoers.d/brew', 'Cmnd_Alias BREW = '.BREW_PREFIX.'/bin/brew *
+%admin ALL=(root) NOPASSWD:SETENV: BREW'.PHP_EOL);
+    }
+
+    /**
+     * Remove the "sudoers.d" entry for running Brew.
+     *
+     * @return void
+     */
+    public function removeSudoersEntry()
+    {
+        $this->cli->quietly('rm /etc/sudoers.d/brew');
+    }
 }

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -66,4 +66,28 @@ class Valet
 
         return version_compare($currentVersion->getVersion(), $response->body->tag_name, '>=');
     }
+
+
+    /**
+     * Create the "sudoers.d" entry for running Valet.
+     *
+     * @return void
+     */
+    public function createSudoersEntry()
+    {
+        $this->files->ensureDirExists('/etc/sudoers.d');
+
+        $this->files->put('/etc/sudoers.d/valet', 'Cmnd_Alias VALET = '.BREW_PREFIX.'/bin/valet *
+%admin ALL=(root) NOPASSWD:SETENV: VALET'.PHP_EOL);
+    }
+
+    /**
+     * Remove the "sudoers.d" entry for running Valet.
+     *
+     * @return void
+     */
+    public function removeSudoersEntry()
+    {
+        $this->cli->quietly('rm /etc/sudoers.d/valet');
+    }
 }

--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -12,6 +12,8 @@ define('VALET_HOME_PATH', $_SERVER['HOME'].'/.valet');
 define('VALET_SERVER_PATH', realpath(__DIR__ . '/../../server.php'));
 define('VALET_STATIC_PREFIX', '41c270e4-5535-4daa-b23e-c269744c2f45');
 
+define('BREW_PREFIX', passthru("sudo -u ".user(). " printf $(brew --prefix)"));
+
 /**
  * Output the given text to the console.
  *

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -481,6 +481,25 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Determine if this is the latest version of Valet');
 
     /**
+     * Install the sudoers.d entries so password is no longer required.
+     */
+    $app->command('trust [--off]', function ($off) {
+        if ($off) {
+            Brew::removeSudoersEntry();
+            Valet::removeSudoersEntry();
+
+            return info('Sudoers entries have been removed for Brew and Valet.');
+        }
+
+        Brew::createSudoersEntry();
+        Valet::createSudoersEntry();
+
+        info('Sudoers entries have been added for Brew and Valet.');
+    })->descriptions('Add sudoers files for Brew and Valet to make Valet commands run without passwords', [
+        '--off' => 'Remove the sudoers files so normal sudo password prompts are required.'
+    ]);
+
+    /**
      * Switch between versions of PHP (Default) or Elasticsearch
      */
     $app->command('use [service] [targetVersion]', function ($service, $targetVersion) {


### PR DESCRIPTION
…d Valet.

- [x] There is an issue ticket which accompanies my PR: <Your-Issue-Link>.
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `<YOUR_TARGET_BRANCH>`:**  
Because this is a Bug Fix which is Backwards Compatible.  
Because this is a Feature which is not Backwards Compatible.  
Because this is a Deprecation which is Backwards Compatible.  
etc...

**Changelog entry:**  
- New command `valet trust` : Add sudoers files for Brew and Valet to allow Valet commands to be run without prompting for your password.
