### PR TITLE
Added support for m1 macs

### DIFF
--- a/cli/Valet/Binaries.php
+++ b/cli/Valet/Binaries.php
@@ -34,17 +34,17 @@ class Binaries
         self::N98_MAGERUN => [
             'url' => 'https://files.magerun.net/n98-magerun-1.103.1.phar',
             'shasum' => 'f4de50f5e7f9db70ee82148339ca865f14b7cdf7713d1f7c9357b84067235ce6',
-            'bin_location' => '/usr/local/bin/'
+            'bin_location' => BREW_PATH . '/bin/'
         ],
         self::N98_MAGERUN_2 => [
             'url' => 'https://files.magerun.net/n98-magerun2-3.2.0.phar',
             'shasum' => '5b5b4f7a857f7716950b6ef090c005c455d5e607f800a50b7b7aefa86d1c4e36',
-            'bin_location' => '/usr/local/bin/'
+            'bin_location' => BREW_PATH . '/bin/'
         ],
         self::DRUSH_LAUNCHER => [
             'url' => 'https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar',
             'shasum' => 'c3f32a800a2f18470b0010cd71c49e49ef5c087f8131eecfe9b686dc1f3f3d4e',
-            'bin_location' => '/usr/local/bin/'
+            'bin_location' => BREW_PATH . '/bin/'
         ]
     ];
 

--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -111,7 +111,7 @@ class Configuration
     public function writeBaseConfiguration()
     {
         if (! $this->files->exists($this->path())) {
-            $this->write(['domain' => 'test', 'paths' => []]);
+            $this->write(['domain' => 'test', 'paths' => [], 'brewPath' => BREW_PATH]);
         }
     }
 

--- a/cli/Valet/DevTools.php
+++ b/cli/Valet/DevTools.php
@@ -113,16 +113,16 @@ class DevTools
         info('Opening Visual Studio Code');
         $command = false;
 
-        if ($this->files->exists('/usr/local/bin/code')) {
-            $command = '/usr/local/bin/code';
+        if ($this->files->exists(BREW_PATH . '/bin/code')) {
+            $command = BREW_PATH . '/bin/code';
         }
 
-        if ($this->files->exists('/usr/local/bin/vscode')) {
-            $command = '/usr/local/bin/vscode';
+        if ($this->files->exists(BREW_PATH . '/bin/vscode')) {
+            $command = BREW_PATH . '/bin/vscode';
         }
 
         if (!$command) {
-            throw new Exception('/usr/local/bin/code command not found. Please install it.');
+            throw new Exception(BREW_PATH . '/bin/code command not found. Please install it.');
         }
 
         $output = $this->cli->runAsUser($command . ' $(git rev-parse --show-toplevel)');

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -9,8 +9,8 @@ class DnsMasq
     public $files;
 
     public $resolverPath = '/etc/resolver';
-    public $configPath = '/usr/local/etc/dnsmasq.conf';
-    public $exampleConfigPath = 'opt/dnsmasq/dnsmasq.conf.example';
+    public $configPath = 'etc/dnsmasq.conf';
+    public $exampleConfigPath = 'var/dnsmasq.conf.default';
 
     /**
      * Create a new DnsMasq instance.
@@ -69,10 +69,10 @@ class DnsMasq
      */
     public function copyExampleConfig()
     {
-        if (! $this->files->exists($this->configPath)) {
+        if (! $this->files->exists(BREW_PATH . "/" . $this->configPath)) {
             $this->files->copyAsUser(
                 BREW_PATH . "/" . $this->exampleConfigPath,
-                $this->configPath
+                BREW_PATH . "/" . $this->configPath
             );
         }
     }
@@ -87,7 +87,7 @@ class DnsMasq
     {
         if (! $this->customConfigIsBeingImported($customConfigPath)) {
             $this->files->appendAsUser(
-                $this->configPath,
+                BREW_PATH . "/" . $this->configPath,
                 PHP_EOL.'conf-file='.$customConfigPath.PHP_EOL
             );
         }
@@ -101,7 +101,7 @@ class DnsMasq
      */
     public function customConfigIsBeingImported($customConfigPath)
     {
-        return strpos($this->files->get($this->configPath), $customConfigPath) !== false;
+        return strpos($this->files->get(BREW_PATH . "/" . $this->configPath), $customConfigPath) !== false;
     }
 
     /**

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -8,9 +8,11 @@ class DnsMasq
     public $cli;
     public $files;
 
+    public $brewPath = '/usr/local';
+
     public $resolverPath = '/etc/resolver';
-    public $configPath = '/usr/local/etc/dnsmasq.conf';
-    public $exampleConfigPath = '/usr/local/opt/dnsmasq/dnsmasq.conf.example';
+    public $configPath = 'etc/dnsmasq.conf';
+    public $exampleConfigPath = 'opt/dnsmasq/dnsmasq.conf.example';
 
     /**
      * Create a new DnsMasq instance.
@@ -31,8 +33,9 @@ class DnsMasq
      *
      * @return void
      */
-    public function install($domain = 'test')
+    public function install($domain = 'test', $brewPath)
     {
+        $this->brewPath = $brewPath;
         $this->brew->ensureInstalled('dnsmasq');
 
         // For DnsMasq, we create our own custom configuration file which will be imported
@@ -69,10 +72,10 @@ class DnsMasq
      */
     public function copyExampleConfig()
     {
-        if (! $this->files->exists($this->configPath)) {
+        if (! $this->files->exists($this-> brewPath . "/" . $this->configPath)) {
             $this->files->copyAsUser(
-                $this->exampleConfigPath,
-                $this->configPath
+                $this-> brewPath . "/" . $this->exampleConfigPath,
+                $this-> brewPath . "/" . $this->configPath
             );
         }
     }
@@ -87,7 +90,7 @@ class DnsMasq
     {
         if (! $this->customConfigIsBeingImported($customConfigPath)) {
             $this->files->appendAsUser(
-                $this->configPath,
+                $this-> brewPath . "/" . $this->configPath,
                 PHP_EOL.'conf-file='.$customConfigPath.PHP_EOL
             );
         }
@@ -101,7 +104,7 @@ class DnsMasq
      */
     public function customConfigIsBeingImported($customConfigPath)
     {
-        return strpos($this->files->get($this->configPath), $customConfigPath) !== false;
+        return strpos($this->files->get($this-> brewPath . "/" . $this->configPath), $customConfigPath) !== false;
     }
 
     /**

--- a/cli/Valet/DnsMasq.php
+++ b/cli/Valet/DnsMasq.php
@@ -8,10 +8,8 @@ class DnsMasq
     public $cli;
     public $files;
 
-    public $brewPath = '/usr/local';
-
     public $resolverPath = '/etc/resolver';
-    public $configPath = 'etc/dnsmasq.conf';
+    public $configPath = '/usr/local/etc/dnsmasq.conf';
     public $exampleConfigPath = 'opt/dnsmasq/dnsmasq.conf.example';
 
     /**
@@ -33,9 +31,8 @@ class DnsMasq
      *
      * @return void
      */
-    public function install($domain = 'test', $brewPath)
+    public function install($domain = 'test')
     {
-        $this->brewPath = $brewPath;
         $this->brew->ensureInstalled('dnsmasq');
 
         // For DnsMasq, we create our own custom configuration file which will be imported
@@ -72,10 +69,10 @@ class DnsMasq
      */
     public function copyExampleConfig()
     {
-        if (! $this->files->exists($this-> brewPath . "/" . $this->configPath)) {
+        if (! $this->files->exists($this->configPath)) {
             $this->files->copyAsUser(
-                $this-> brewPath . "/" . $this->exampleConfigPath,
-                $this-> brewPath . "/" . $this->configPath
+                BREW_PATH . "/" . $this->exampleConfigPath,
+                $this->configPath
             );
         }
     }
@@ -90,7 +87,7 @@ class DnsMasq
     {
         if (! $this->customConfigIsBeingImported($customConfigPath)) {
             $this->files->appendAsUser(
-                $this-> brewPath . "/" . $this->configPath,
+                $this->configPath,
                 PHP_EOL.'conf-file='.$customConfigPath.PHP_EOL
             );
         }
@@ -104,7 +101,7 @@ class DnsMasq
      */
     public function customConfigIsBeingImported($customConfigPath)
     {
-        return strpos($this->files->get($this-> brewPath . "/" . $this->configPath), $customConfigPath) !== false;
+        return strpos($this->files->get($this->configPath), $customConfigPath) !== false;
     }
 
     /**

--- a/cli/Valet/Elasticsearch.php
+++ b/cli/Valet/Elasticsearch.php
@@ -7,7 +7,7 @@ use DomainException;
 class Elasticsearch
 {
     const NGINX_CONFIGURATION_STUB = __DIR__ . '/../stubs/elasticsearch.conf';
-    const NGINX_CONFIGURATION_PATH = '/usr/local/etc/nginx/valet/elasticsearch.conf';
+    const NGINX_CONFIGURATION_PATH = 'etc/nginx/valet/elasticsearch.conf';
 
     const ES_CONFIG_YAML          = '/usr/local/etc/elasticsearch/elasticsearch.yml';
     const ES_CONFIG_DATA_PATH     = 'path.data';
@@ -163,7 +163,7 @@ class Elasticsearch
     public function updateDomain($domain)
     {
         $this->files->putAsUser(
-            self::NGINX_CONFIGURATION_PATH,
+            BREW_PATH . '/' . self::NGINX_CONFIGURATION_PATH,
             str_replace(
                 ['VALET_DOMAIN'],
                 [$domain],

--- a/cli/Valet/Mailhog.php
+++ b/cli/Valet/Mailhog.php
@@ -5,7 +5,7 @@ namespace Valet;
 class Mailhog extends AbstractService
 {
     const NGINX_CONFIGURATION_STUB = __DIR__ . '/../stubs/mailhog.conf';
-    const NGINX_CONFIGURATION_PATH = '/usr/local/etc/nginx/valet/mailhog.conf';
+    const NGINX_CONFIGURATION_PATH = 'etc/nginx/valet/mailhog.conf';
 
     public $brew;
     public $cli;
@@ -104,7 +104,7 @@ class Mailhog extends AbstractService
     public function updateDomain($domain)
     {
         $this->files->putAsUser(
-            self::NGINX_CONFIGURATION_PATH,
+            BREW_PATH . '/' . self::NGINX_CONFIGURATION_PATH,
             str_replace(
                 ['VALET_DOMAIN'],
                 [$domain],

--- a/cli/Valet/Mysql.php
+++ b/cli/Valet/Mysql.php
@@ -14,7 +14,7 @@ class Mysql
     const MYSQL_DIR = 'var/mysql';
     const MYSQL_ROOT_PASSWORD = 'root';
 
-    public $brew;    
+    public $brew;
     public $cli;
     public $files;
     public $configuration;

--- a/cli/Valet/Mysql.php
+++ b/cli/Valet/Mysql.php
@@ -8,13 +8,14 @@ use MYSQLI_ASSOC;
 
 class Mysql
 {
-    const MYSQL_CONF_DIR = '/usr/local/etc';
-    const MYSQL_CONF = '/usr/local/etc/my.cnf';
+    const MYSQL_CONF_DIR = 'etc';
+    const MYSQL_CONF = 'etc/my.cnf';
     const MAX_FILES_CONF = '/Library/LaunchDaemons/limit.maxfiles.plist';
-    const MYSQL_DIR = '/usr/local/var/mysql';
+    const MYSQL_DIR = 'var/mysql';
     const MYSQL_ROOT_PASSWORD = 'root';
 
     public $brew;
+    public $brewPath;
     public $cli;
     public $files;
     public $configuration;
@@ -53,8 +54,10 @@ class Mysql
      *
      * @param $type
      */
-    public function install($type = 'mysql@5.7')
+    public function install($type = 'mysql@5.7', $brewPath = '/usr/local')
     {
+        $this->brewPath = $brewPath;
+
         $this->verifyType($type);
         $currentlyInstalled = $this->installedVersion();
         if ($currentlyInstalled) {
@@ -126,8 +129,8 @@ class Mysql
      */
     private function removeConfiguration($type = 'mysql@5.7')
     {
-        $this->files->unlink(static::MYSQL_CONF);
-        $this->files->unlink(static::MYSQL_CONF . '.default');
+        $this->files->unlink($this->brewPath . "/" . static::MYSQL_CONF);
+        $this->files->unlink($this->brewPath . "/" . static::MYSQL_CONF . '.default');
     }
 
     /**
@@ -151,9 +154,9 @@ class Mysql
     {
         info('[' . $type . '] Configuring');
 
-        $this->files->chmodPath(static::MYSQL_DIR, 0777);
+        $this->files->chmodPath($this->brewPath . "/" . static::MYSQL_DIR, 0777);
 
-        if (!$this->files->isDir($directory = static::MYSQL_CONF_DIR)) {
+        if (!$this->files->isDir($directory = $this->brewPath . "/" . static::MYSQL_CONF_DIR)) {
             $this->files->mkdirAsUser($directory);
         }
 
@@ -163,7 +166,7 @@ class Mysql
         }
 
         $this->files->putAsUser(
-            static::MYSQL_CONF,
+            $this->brewPath . "/" . static::MYSQL_CONF,
             \str_replace('VALET_HOME_PATH', VALET_HOME_PATH, $contents)
         );
     }

--- a/cli/Valet/Mysql.php
+++ b/cli/Valet/Mysql.php
@@ -14,8 +14,7 @@ class Mysql
     const MYSQL_DIR = 'var/mysql';
     const MYSQL_ROOT_PASSWORD = 'root';
 
-    public $brew;
-    public $brewPath;
+    public $brew;    
     public $cli;
     public $files;
     public $configuration;
@@ -54,10 +53,8 @@ class Mysql
      *
      * @param $type
      */
-    public function install($type = 'mysql@5.7', $brewPath = '/usr/local')
+    public function install($type = 'mysql@5.7')
     {
-        $this->brewPath = $brewPath;
-
         $this->verifyType($type);
         $currentlyInstalled = $this->installedVersion();
         if ($currentlyInstalled) {
@@ -129,8 +126,8 @@ class Mysql
      */
     private function removeConfiguration($type = 'mysql@5.7')
     {
-        $this->files->unlink($this->brewPath . "/" . static::MYSQL_CONF);
-        $this->files->unlink($this->brewPath . "/" . static::MYSQL_CONF . '.default');
+        $this->files->unlink(BREW_PATH . "/" . static::MYSQL_CONF);
+        $this->files->unlink(BREW_PATH . "/" . static::MYSQL_CONF . '.default');
     }
 
     /**
@@ -154,9 +151,9 @@ class Mysql
     {
         info('[' . $type . '] Configuring');
 
-        $this->files->chmodPath($this->brewPath . "/" . static::MYSQL_DIR, 0777);
+        $this->files->chmodPath(BREW_PATH . "/" . static::MYSQL_DIR, 0777);
 
-        if (!$this->files->isDir($directory = $this->brewPath . "/" . static::MYSQL_CONF_DIR)) {
+        if (!$this->files->isDir($directory = BREW_PATH . "/" . static::MYSQL_CONF_DIR)) {
             $this->files->mkdirAsUser($directory);
         }
 
@@ -166,7 +163,7 @@ class Mysql
         }
 
         $this->files->putAsUser(
-            $this->brewPath . "/" . static::MYSQL_CONF,
+            BREW_PATH . "/" . static::MYSQL_CONF,
             \str_replace('VALET_HOME_PATH', VALET_HOME_PATH, $contents)
         );
     }

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -11,7 +11,7 @@ class Nginx
     public $files;
     public $configuration;
     public $site;
-    const NGINX_CONF = '/usr/local/etc/nginx/nginx.conf';
+    const NGINX_CONF = 'etc/nginx/nginx.conf';
 
     /**
      * Create a new Nginx instance.
@@ -64,7 +64,7 @@ class Nginx
         $contents = $this->files->get(__DIR__.'/../stubs/nginx.conf');
 
         $this->files->putAsUser(
-            static::NGINX_CONF,
+            BREW_PATH . "/" . static::NGINX_CONF,
             str_replace(['VALET_USER', 'VALET_HOME_PATH'], [user(), VALET_HOME_PATH], $contents)
         );
     }
@@ -78,10 +78,10 @@ class Nginx
     {
         $domain = $this->configuration->read()['domain'];
 
-        $this->files->ensureDirExists('/usr/local/etc/nginx/valet');
+        $this->files->ensureDirExists(BREW_PATH . '/etc/nginx/valet');
 
         $this->files->putAsUser(
-            '/usr/local/etc/nginx/valet/valet.conf',
+            BREW_PATH . '/etc/nginx/valet/valet.conf',
             str_replace(
                 ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX'],
                 [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX],
@@ -90,7 +90,7 @@ class Nginx
         );
 
         $this->files->putAsUser(
-            '/usr/local/etc/nginx/fastcgi_params',
+            BREW_PATH . '/etc/nginx/fastcgi_params',
             $this->files->get(__DIR__.'/../stubs/fastcgi_params')
         );
     }
@@ -119,7 +119,7 @@ class Nginx
     private function lint()
     {
         $this->cli->quietly(
-            'sudo nginx -c '.static::NGINX_CONF.' -t',
+            'sudo nginx -c '.BREW_PATH ."/".static::NGINX_CONF.' -t',
             function ($exitCode, $outputMessage) {
                 throw new DomainException("Nginx cannot start, please check your nginx.conf [$exitCode: $outputMessage].");
             }

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -80,6 +80,7 @@ class Pecl extends AbstractPecl
     ];
 
     public $peclCustom;
+    public $brewDir;
 
     /**
      * @inheritdoc
@@ -315,8 +316,9 @@ class Pecl extends AbstractPecl
     /**
      * Fix common problems related to the PECL/PEAR installation.
      */
-    public function fix()
+    public function fix($brewDir="/usr/local")
     {
+        $this->brewDir = $brewDir;
         info('[PECL] Checking pear config...');
         // Check if pear config is set correctly as per:
         // https://github.com/kabel/homebrew-core/blob/2564749d8f73e43cbb8cfc449bca4f564ac0e9e1/Formula/php%405.6.rb
@@ -324,7 +326,7 @@ class Pecl extends AbstractPecl
         foreach (PhpFpm::SUPPORTED_PHP_FORMULAE as $phpVersion => $brewname) {
             output("Checking php $phpVersion...");
 
-            $pearConfigPath = PhpFpm::LOCAL_PHP_FOLDER . "$phpVersion/pear.conf";
+            $pearConfigPath = $this->brewDir . PhpFpm::LOCAL_PHP_FOLDER . "$phpVersion/pear.conf";
 
             if (!$this->files->exists($pearConfigPath)) {
                 warning("    Skipping $phpVersion, Pear config path could not be found at: $pearConfigPath");
@@ -354,16 +356,16 @@ class Pecl extends AbstractPecl
             $pearName = $this->replacePhpWithPear($brewname);
 
             $phpIniPath = str_replace('pear.conf', 'php.ini', $pearConfigPath);
-            $phpDirPath = "/usr/local/share/$pearName";
-            $pearDocDirPath = "/usr/local/share/$pearName/doc";
+            $phpDirPath = $this->brewDir . "/share/$pearName";
+            $pearDocDirPath = $this->brewDir . "/share/$pearName/doc";
             $phpExtensionDirPath = '/usr/local/lib/php/pecl/'.basename($pearConfig['ext_dir']);
-            $phpBinPath = "/usr/local/opt/$brewname/bin";
-            $pearDataDirPath = "/usr/local/share/$pearName/data";
-            $pearCfgDirPath = "/usr/local/share/$pearName/cfg";
-            $pearWwwDirPath = "/usr/local/share/$pearName/htdocs";
+            $phpBinPath = $this->brewDir . "/opt/$brewname/bin";
+            $pearDataDirPath = $this->brewDir . "/share/$pearName/data";
+            $pearCfgDirPath = $this->brewDir . "/share/$pearName/cfg";
+            $pearWwwDirPath = $this->brewDir . "/share/$pearName/htdocs";
             $pearManDirPath = '/usr/local/share/man';
-            $pearTestDirPath = "/usr/local/share/$pearName/test";
-            $phpBinDirPath = "/usr/local/opt/$brewname/bin/php";
+            $pearTestDirPath = $this->brewDir . "/share/$pearName/test";
+            $phpBinDirPath = $this->brewDir . "/opt/$brewname/bin/php";
 
             // Check php_ini value of par config.
             if (empty($pearConfig['php_ini']) || $pearConfig['php_ini'] !== $phpIniPath) {

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -435,10 +435,6 @@ class Pecl extends AbstractPecl
 
             // Put config back into the pear.conf file.
             $this->files->put($pearConfigPath, $pearConfig);
-
-
-            // pecl config-set php_dir /opt/homebrew/share/valet-pear@7.2
-            // pear config-set php_dir /opt/homebrew/share/valet-pear@7.2
         }
     }
 

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -82,7 +82,6 @@ class Pecl extends AbstractPecl
     ];
 
     public $peclCustom;
-    public $brewDir;
 
     /**
      * @inheritdoc
@@ -322,9 +321,8 @@ class Pecl extends AbstractPecl
     /**
      * Fix common problems related to the PECL/PEAR installation.
      */
-    public function fix($brewDir="/usr/local")
+    public function fix()
     {
-        $this->brewDir = $brewDir;
         info('[PECL] Checking pear config...');
         // Check if pear config is set correctly as per:
         // https://github.com/kabel/homebrew-core/blob/2564749d8f73e43cbb8cfc449bca4f564ac0e9e1/Formula/php%405.6.rb
@@ -332,7 +330,7 @@ class Pecl extends AbstractPecl
         foreach (PhpFpm::SUPPORTED_PHP_FORMULAE as $phpVersion => $brewname) {
             output("Checking php $phpVersion...");
 
-            $pearConfigPath = $this->brewDir . PhpFpm::LOCAL_PHP_FOLDER . "$phpVersion/pear.conf";
+            $pearConfigPath = BREW_PATH . PhpFpm::LOCAL_PHP_FOLDER . "$phpVersion/pear.conf";
 
             if (!$this->files->exists($pearConfigPath)) {
                 warning("    Skipping $phpVersion, Pear config path could not be found at: $pearConfigPath");
@@ -362,16 +360,16 @@ class Pecl extends AbstractPecl
             $pearName = $this->replacePhpWithPear($brewname);
 
             $phpIniPath = str_replace('pear.conf', 'php.ini', $pearConfigPath);
-            $phpDirPath = $this->brewDir . "/share/$pearName";
-            $pearDocDirPath = $this->brewDir . "/share/$pearName/doc";
-            $phpExtensionDirPath = $this->brewDir . '/lib/php/pecl/'.basename($pearConfig['ext_dir']);
-            $phpBinPath = $this->brewDir . "/opt/$brewname/bin";
-            $pearDataDirPath = $this->brewDir . "/share/$pearName/data";
-            $pearCfgDirPath = $this->brewDir . "/share/$pearName/cfg";
-            $pearWwwDirPath = $this->brewDir . "/share/$pearName/htdocs";
+            $phpDirPath = BREW_PATH . "/share/$pearName";
+            $pearDocDirPath = BREW_PATH . "/share/$pearName/doc";
+            $phpExtensionDirPath = BREW_PATH . '/lib/php/pecl/'.basename($pearConfig['ext_dir']);
+            $phpBinPath = BREW_PATH . "/opt/$brewname/bin";
+            $pearDataDirPath = BREW_PATH . "/share/$pearName/data";
+            $pearCfgDirPath = BREW_PATH . "/share/$pearName/cfg";
+            $pearWwwDirPath = BREW_PATH . "/share/$pearName/htdocs";
             $pearManDirPath = '/usr/local/share/man';
-            $pearTestDirPath = $this->brewDir . "/share/$pearName/test";
-            $phpBinDirPath = $this->brewDir . "/opt/$brewname/bin/php";
+            $pearTestDirPath = BREW_PATH . "/share/$pearName/test";
+            $phpBinDirPath = BREW_PATH . "/opt/$brewname/bin/php";
 
             // Check php_ini value of par config.
             if (empty($pearConfig['php_ini']) || $pearConfig['php_ini'] !== $phpIniPath) {

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -54,7 +54,7 @@ class Pecl extends AbstractPecl
             '7.1' => '5.1.17',
             '7.0' => '5.1.17',
             '5.6' => '4.0.11',
-            'extension_type' => self::NORMAL_EXTENSION_TYPE            
+            'extension_type' => self::NORMAL_EXTENSION_TYPE
         ],
         // self::GEOIP_EXTENSION => [
         //     '7.4' => '1.1.1',
@@ -139,11 +139,11 @@ class Pecl extends AbstractPecl
     protected function install($extension, $version = null)
     {
         if ($version === null) {
-            if($this->hasBrewDependency($extension)) {
+            if ($this->hasBrewDependency($extension)) {
                 $result = $this->cli->runAsUser("echo $(brew --prefix " . $this->getBrewDependency($extension) . ") | pecl install $extension");
             } else {
                 $result = $this->cli->runAsUser("pecl install $extension");
-            }            
+            }
         } else {
             $result = $this->cli->runAsUser("pecl install $extension-$version");
         }
@@ -536,9 +536,9 @@ class Pecl extends AbstractPecl
 
     /**
      * Check if the extension has any brew dependency
-     * 
-     * @param mixed $extension 
-     * @return bool 
+     *
+     * @param mixed $extension
+     * @return bool
      */
     private function hasBrewDependency($extension)
     {
@@ -548,9 +548,9 @@ class Pecl extends AbstractPecl
 
     /**
      * Get the brew dependency for the pecl command
-     * 
-     * @param mixed $extension 
-     * @return mixed 
+     *
+     * @param mixed $extension
+     * @return mixed
      */
     private function getBrewDependency($extension)
     {

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -367,7 +367,7 @@ class Pecl extends AbstractPecl
             $pearDataDirPath = BREW_PATH . "/share/$pearName/data";
             $pearCfgDirPath = BREW_PATH . "/share/$pearName/cfg";
             $pearWwwDirPath = BREW_PATH . "/share/$pearName/htdocs";
-            $pearManDirPath = '/usr/local/share/man';
+            $pearManDirPath = BREW_PATH . '/share/man';
             $pearTestDirPath = BREW_PATH . "/share/$pearName/test";
             $phpBinDirPath = BREW_PATH . "/opt/$brewname/bin/php";
 

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -473,7 +473,7 @@ class PhpFpm
      * Fixes common problems with php installations from Homebrew.
      */
     public function fix($reinstall)
-    {        
+    {
         // If the current php is not 7.2, link 7.2.
         info('Check Valet+ PHP version...');
         info('Run valet fix with the --reinstall option to trigger a full reinstall of the default PHP version.');

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -65,10 +65,8 @@ class PhpFpm
      *
      * @return void
      */
-    public function install($brewDir="/usr/local")
+    public function install()
     {
-        $this->brewDir = $brewDir;
-
         if (!$this->hasInstalledPhp()) {
             $this->brew->ensureInstalled($this->getFormulaName(self::PHP_V72_VERSION));
         }
@@ -82,7 +80,7 @@ class PhpFpm
 
         $version = $this->linkedPhp();
 
-        $this->files->ensureDirExists($this->brewDir . '/var/log', user());
+        $this->files->ensureDirExists(BREW_PATH . '/var/log', user());
         $this->updateConfiguration();
         $this->pecl->updatePeclChannel();
         $this->pecl->installExtensions($version);
@@ -127,13 +125,13 @@ class PhpFpm
     public function fpmConfigPath()
     {
         $confLookup = [
-            self::PHP_V80_VERSION => $this->brewDir . self::LOCAL_PHP_FOLDER . '8.0/php-fpm.d/www.conf',
-            self::PHP_V74_VERSION => $this->brewDir . self::LOCAL_PHP_FOLDER . '7.4/php-fpm.d/www.conf',
-            self::PHP_V73_VERSION => $this->brewDir . self::LOCAL_PHP_FOLDER . '7.3/php-fpm.d/www.conf',
-            self::PHP_V72_VERSION => $this->brewDir . self::LOCAL_PHP_FOLDER . '7.2/php-fpm.d/www.conf',
-            self::PHP_V71_VERSION => $this->brewDir . self::LOCAL_PHP_FOLDER . '7.1/php-fpm.d/www.conf',
-            self::PHP_V70_VERSION => $this->brewDir . self::LOCAL_PHP_FOLDER . '7.0/php-fpm.d/www.conf',
-            self::PHP_V56_VERSION => $this->brewDir . self::LOCAL_PHP_FOLDER . '5.6/php-fpm.conf',
+            self::PHP_V80_VERSION => BREW_PATH . self::LOCAL_PHP_FOLDER . '8.0/php-fpm.d/www.conf',
+            self::PHP_V74_VERSION => BREW_PATH . self::LOCAL_PHP_FOLDER . '7.4/php-fpm.d/www.conf',
+            self::PHP_V73_VERSION => BREW_PATH . self::LOCAL_PHP_FOLDER . '7.3/php-fpm.d/www.conf',
+            self::PHP_V72_VERSION => BREW_PATH . self::LOCAL_PHP_FOLDER . '7.2/php-fpm.d/www.conf',
+            self::PHP_V71_VERSION => BREW_PATH . self::LOCAL_PHP_FOLDER . '7.1/php-fpm.d/www.conf',
+            self::PHP_V70_VERSION => BREW_PATH . self::LOCAL_PHP_FOLDER . '7.0/php-fpm.d/www.conf',
+            self::PHP_V56_VERSION => BREW_PATH . self::LOCAL_PHP_FOLDER . '5.6/php-fpm.conf',
         ];
 
         return $confLookup[$this->linkedPhp()];
@@ -376,11 +374,11 @@ class PhpFpm
      */
     public function linkedPhp()
     {
-        if (!$this->files->isLink($this->brewDir . '/bin/php')) {
+        if (!$this->files->isLink(BREW_PATH . '/bin/php')) {
             throw new DomainException("Unable to determine linked PHP.");
         }
 
-        $resolvedPath = $this->files->readLink($this->brewDir . '/bin/php');
+        $resolvedPath = $this->files->readLink(BREW_PATH . '/bin/php');
 
         $versions = self::SUPPORTED_PHP_FORMULAE;
 
@@ -474,10 +472,8 @@ class PhpFpm
     /**
      * Fixes common problems with php installations from Homebrew.
      */
-    public function fix($reinstall, $brewDir="/usr/local")
-    {
-        $this->brewDir = $brewDir;
-        
+    public function fix($reinstall)
+    {        
         // If the current php is not 7.2, link 7.2.
         info('Check Valet+ PHP version...');
         info('Run valet fix with the --reinstall option to trigger a full reinstall of the default PHP version.');

--- a/cli/Valet/RedisTool.php
+++ b/cli/Valet/RedisTool.php
@@ -9,7 +9,7 @@ class RedisTool extends AbstractService
     public $files;
     public $site;
 
-    const REDIS_CONF = '/usr/local/etc/redis.conf';
+    const REDIS_CONF = 'etc/redis.conf';
 
     /**
      * Create a new instance.
@@ -70,7 +70,12 @@ class RedisTool extends AbstractService
      */
     public function installConfiguration()
     {
-        $this->files->copy(__DIR__.'/../stubs/redis.conf', static::REDIS_CONF);
+        $contents = $this->files->get(__DIR__.'/../stubs/redis.conf');
+
+        $this->files->put(
+            BREW_PATH . "/" . static::REDIS_CONF, 
+            str_replace('BREW_PATH', BREW_PATH, $contents)
+        );
     }
 
     /**

--- a/cli/stubs/nginx.conf
+++ b/cli/stubs/nginx.conf
@@ -6,6 +6,7 @@ events {
 }
 
 http {
+    server_names_hash_bucket_size  64;
     include mime.types;
     default_type  application/octet-stream;
 

--- a/cli/stubs/redis.conf
+++ b/cli/stubs/redis.conf
@@ -244,7 +244,7 @@ dbfilename dump.rdb
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir /usr/local/var/db/redis/
+dir BREW_PATH/var/db/redis/
 
 ################################# REPLICATION #################################
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -38,7 +38,8 @@ if (is_dir(VALET_HOME_PATH)) {
 /**
  * Allow Valet to be run more conveniently by allowing the Node proxy to run password-less sudo.
  */
-$app->command('install [--with-mariadb]', function ($withMariadb) {
+$app->command('install [--with-mariadb] [--brew-opt]', function ($withMariadb, $brewOpt) {
+        
     Nginx::stop();
     PhpFpm::stop();
     Mysql::stop();
@@ -48,7 +49,7 @@ $app->command('install [--with-mariadb]', function ($withMariadb) {
 
     Configuration::install();
     $domain = Nginx::install();
-    PhpFpm::install();
+    PhpFpm::install($brewOpt ? '/opt/homebrew' : '/usr/local');
     DnsMasq::install();
     Mysql::install($withMariadb ? 'mariadb' : 'mysql@5.7');
     RedisTool::install();
@@ -66,13 +67,13 @@ $app->command('install [--with-mariadb]', function ($withMariadb) {
 /**
  * Fix common problems within the Valet+ installation.
  */
-$app->command('fix [--reinstall]', function ($reinstall) {
+$app->command('fix [--reinstall] [--brew-opt]', function ($reinstall, $brewOpt) {
     if (file_exists($_SERVER['HOME'] . '/.my.cnf')) {
         warning('You have an .my.cnf file in your home directory. This can affect the mysql installation negatively.');
     }
 
-    PhpFpm::fix($reinstall);
-    Pecl::fix();
+    PhpFpm::fix($reinstall, $brewOpt ? '/opt/homebrew' : '/usr/local');
+    Pecl::fix($brewOpt ? '/opt/homebrew' : '/usr/local');
 })->descriptions('Fixes common installation problems that prevent Valet+ from working');
 
 /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -33,6 +33,8 @@ if (is_dir(VALET_HOME_PATH)) {
     Configuration::prune();
 
     Site::pruneLinks();
+
+    define('BREW_PATH', Configuration::read()['brewPath']);
 }
 
 /**
@@ -206,8 +208,6 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('secure [domain]', function ($domain = null) {
 
-        define('BREW_PATH', Configuration::read()['brewPath']);
-
         $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
 
         Site::secure($url);
@@ -223,8 +223,6 @@ if (is_dir(VALET_HOME_PATH)) {
      * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.
      */
     $app->command('unsecure [domain]', function ($domain = null) {
-
-        define('BREW_PATH', Configuration::read()['brewPath']);
 
         $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
 
@@ -367,8 +365,6 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('restart [services]*', function ($services) {
 
-        define('BREW_PATH', Configuration::read()['brewPath']);
-
         if (empty($services)) {
             DnsMasq::restart();
             PhpFpm::restart();
@@ -510,9 +506,6 @@ if (is_dir(VALET_HOME_PATH)) {
         }
         $service = (isset($supportedServices[$service]) ? $supportedServices[$service] : false);
 
-        $config = Configuration::read();
-        define('BREW_PATH', Configuration::read()['brewPath']);
-
         switch ($service) {
             case 'php':
                 PhpFpm::switchTo($targetVersion);
@@ -531,8 +524,6 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('db [run] [name] [optional] [-y|--yes]', function ($input, $output, $run, $name, $optional) {
         $helper = $this->getHelperSet()->get('question');
         $defaults = $input->getOptions();
-
-        define('BREW_PATH', Configuration::read()['brewPath']);
 
         if ($run === 'list' || $run === 'ls') {
             Mysql::listDatabases();
@@ -954,11 +945,11 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('logs [service]', function ($service) {
         $logs = [
             'php' => '$HOME/.valet/Log/php.log',
-            'php-fpm' => '/usr/local/var/log/php-fpm.log',
+            'php-fpm' => BREW_PATH . '/var/log/php-fpm.log',
             'nginx' => '$HOME/.valet/Log/nginx-error.log',
             'mysql' => '$HOME/.valet/Log/mysql.log',
-            'mailhog' => '/usr/local/var/log/mailhog.log',
-            'redis' => '/usr/local/var/log/redis.log',
+            'mailhog' => BREW_PATH . '/var/log/mailhog.log',
+            'redis' => BREW_PATH . '/var/log/redis.log',
         ];
 
         if (!isset($logs[$service])) {

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -40,6 +40,8 @@ if (is_dir(VALET_HOME_PATH)) {
  */
 $app->command('install [--with-mariadb] [--brew-opt]', function ($withMariadb, $brewOpt) {
         
+    define('BREW_PATH', $brewOpt ? '/opt/homebrew' : '/usr/local');
+
     Nginx::stop();
     PhpFpm::stop();
     Mysql::stop();
@@ -48,12 +50,12 @@ $app->command('install [--with-mariadb] [--brew-opt]', function ($withMariadb, $
     Binaries::installBinaries();
 
     Configuration::install();
-    $domain = Nginx::install();
+    $domain = Nginx::install($brewOpt ? '/opt/homebrew' : '/usr/local');
     PhpFpm::install($brewOpt ? '/opt/homebrew' : '/usr/local');
     DnsMasq::install('test', $brewOpt ? '/opt/homebrew' : '/usr/local');
     Mysql::install($withMariadb ? 'mariadb' : 'mysql@5.7', $brewOpt ? '/opt/homebrew' : '/usr/local');
     RedisTool::install();
-    Mailhog::install();
+    Mailhog::install($brewOpt ? '/opt/homebrew' : '/usr/local');
     Nginx::restart();
     Valet::symlinkToUsersBin();
     Mysql::setRootPassword();

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -50,8 +50,8 @@ $app->command('install [--with-mariadb] [--brew-opt]', function ($withMariadb, $
     Configuration::install();
     $domain = Nginx::install();
     PhpFpm::install($brewOpt ? '/opt/homebrew' : '/usr/local');
-    DnsMasq::install();
-    Mysql::install($withMariadb ? 'mariadb' : 'mysql@5.7');
+    DnsMasq::install('test', $brewOpt ? '/opt/homebrew' : '/usr/local');
+    Mysql::install($withMariadb ? 'mariadb' : 'mysql@5.7', $brewOpt ? '/opt/homebrew' : '/usr/local');
     RedisTool::install();
     Mailhog::install();
     Nginx::restart();

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -205,6 +205,9 @@ if (is_dir(VALET_HOME_PATH)) {
      * Secure the given domain with a trusted TLS certificate.
      */
     $app->command('secure [domain]', function ($domain = null) {
+
+        define('BREW_PATH', Configuration::read()['brewPath']);
+
         $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
 
         Site::secure($url);
@@ -220,6 +223,9 @@ if (is_dir(VALET_HOME_PATH)) {
      * Stop serving the given domain over HTTPS and remove the trusted TLS certificate.
      */
     $app->command('unsecure [domain]', function ($domain = null) {
+
+        define('BREW_PATH', Configuration::read()['brewPath']);
+
         $url = ($domain ?: Site::host(getcwd())).'.'.Configuration::read()['domain'];
 
         $proxied = Site::proxied($url);

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -50,12 +50,12 @@ $app->command('install [--with-mariadb] [--brew-opt]', function ($withMariadb, $
     Binaries::installBinaries();
 
     Configuration::install();
-    $domain = Nginx::install($brewOpt ? '/opt/homebrew' : '/usr/local');
-    PhpFpm::install($brewOpt ? '/opt/homebrew' : '/usr/local');
-    DnsMasq::install('test', $brewOpt ? '/opt/homebrew' : '/usr/local');
-    Mysql::install($withMariadb ? 'mariadb' : 'mysql@5.7', $brewOpt ? '/opt/homebrew' : '/usr/local');
+    $domain = Nginx::install();
+    PhpFpm::install();
+    DnsMasq::install('test');
+    Mysql::install($withMariadb ? 'mariadb' : 'mysql@5.7');
     RedisTool::install();
-    Mailhog::install($brewOpt ? '/opt/homebrew' : '/usr/local');
+    Mailhog::install();
     Nginx::restart();
     Valet::symlinkToUsersBin();
     Mysql::setRootPassword();
@@ -69,13 +69,13 @@ $app->command('install [--with-mariadb] [--brew-opt]', function ($withMariadb, $
 /**
  * Fix common problems within the Valet+ installation.
  */
-$app->command('fix [--reinstall]', function ($reinstall) {
+$app->command('fix [--reinstall] [--brew-opt]', function ($reinstall, $brewOpt) {
+
+    define('BREW_PATH', $brewOpt ? '/opt/homebrew' : '/usr/local');
+
     if (file_exists($_SERVER['HOME'] . '/.my.cnf')) {
         warning('You have an .my.cnf file in your home directory. This can affect the mysql installation negatively.');
     }
-
-    $config = Configuration::read();
-    define('BREW_PATH', $config['brewPath']);
 
     PhpFpm::fix($reinstall);
     Pecl::fix();
@@ -361,8 +361,7 @@ if (is_dir(VALET_HOME_PATH)) {
      */
     $app->command('restart [services]*', function ($services) {
 
-        $config = Configuration::read();
-        define('BREW_PATH', $config['brewPath']);
+        define('BREW_PATH', Configuration::read()['brewPath']);
 
         if (empty($services)) {
             DnsMasq::restart();
@@ -506,7 +505,7 @@ if (is_dir(VALET_HOME_PATH)) {
         $service = (isset($supportedServices[$service]) ? $supportedServices[$service] : false);
 
         $config = Configuration::read();
-        define('BREW_PATH', $config['brewPath']);
+        define('BREW_PATH', Configuration::read()['brewPath']);
 
         switch ($service) {
             case 'php':

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -69,13 +69,16 @@ $app->command('install [--with-mariadb] [--brew-opt]', function ($withMariadb, $
 /**
  * Fix common problems within the Valet+ installation.
  */
-$app->command('fix [--reinstall] [--brew-opt]', function ($reinstall, $brewOpt) {
+$app->command('fix [--reinstall]', function ($reinstall) {
     if (file_exists($_SERVER['HOME'] . '/.my.cnf')) {
         warning('You have an .my.cnf file in your home directory. This can affect the mysql installation negatively.');
     }
 
-    PhpFpm::fix($reinstall, $brewOpt ? '/opt/homebrew' : '/usr/local');
-    Pecl::fix($brewOpt ? '/opt/homebrew' : '/usr/local');
+    $config = Configuration::read();
+    define('BREW_PATH', $config['brewPath']);
+
+    PhpFpm::fix($reinstall);
+    Pecl::fix();
 })->descriptions('Fixes common installation problems that prevent Valet+ from working');
 
 /**
@@ -357,6 +360,10 @@ if (is_dir(VALET_HOME_PATH)) {
      * Restart the daemon services.
      */
     $app->command('restart [services]*', function ($services) {
+
+        $config = Configuration::read();
+        define('BREW_PATH', $config['brewPath']);
+
         if (empty($services)) {
             DnsMasq::restart();
             PhpFpm::restart();
@@ -497,6 +504,9 @@ if (is_dir(VALET_HOME_PATH)) {
             $service       = 'php';
         }
         $service = (isset($supportedServices[$service]) ? $supportedServices[$service] : false);
+
+        $config = Configuration::read();
+        define('BREW_PATH', $config['brewPath']);
 
         switch ($service) {
             case 'php':

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -532,6 +532,8 @@ if (is_dir(VALET_HOME_PATH)) {
         $helper = $this->getHelperSet()->get('question');
         $defaults = $input->getOptions();
 
+        define('BREW_PATH', Configuration::read()['brewPath']);
+
         if ($run === 'list' || $run === 'ls') {
             Mysql::listDatabases();
             return;


### PR DESCRIPTION
- [/] There is an issue ticket which accompanies my PR: #568 
- [/] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [/] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [/] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `2.x`:
Because this is a Feature which is Backwards Compatible. 

**Changelog entry:**  

### Added
 - Added new flag `--brew-opt` for install command which tells valet to look in `/opt/homebrew`
 - Added new flag `--brew-opt` for fix command which tells valet to look in `/opt/homebrew`

### Removed
 - GEOIP is not installed as proved problematic due to brew path changes and installing via pecl

### Note
If using php 7.3 and greater you need the following for a successful install of apcu
```
export LDFLAGS="-L/opt/homebrew/opt/pcre2/lib"
export CPPFLAGS="-I/opt/homebrew/opt/pcre2/include"
export PKG_CONFIG_PATH="/opt/homebrew/opt/pcre2/lib/pkgconfig"
```