### PR TITLE
ioncube-support-for-php-74 +: Add support for ioncube PHP 7.4

### DIFF
--- a/cli/Valet/PeclCustom.php
+++ b/cli/Valet/PeclCustom.php
@@ -8,7 +8,7 @@ class PeclCustom extends AbstractPecl
 {
 
     // Extensions.
-    const IONCUBE_LOADER_EXTENSION = 'ioncube_loader_dar';
+    const IONCUBE_LOADER_EXTENSION = 'ioncube_loader_mac';
 
     // File extensions.
     const TAR_GZ_FILE_EXTENSION = '.tar.gz';
@@ -53,11 +53,12 @@ class PeclCustom extends AbstractPecl
      */
     const EXTENSIONS = [
         self::IONCUBE_LOADER_EXTENSION => [
-            '7.3' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '7.2' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '7.1' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '7.0' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
-            '5.6' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_dar_x86-64.tar.gz',
+            '7.4' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_mac_x86-64.tar.gz',
+            '7.3' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_mac_x86-64.tar.gz',
+            '7.2' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_mac_x86-64.tar.gz',
+            '7.1' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_mac_x86-64.tar.gz',
+            '7.0' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_mac_x86-64.tar.gz',
+            '5.6' => 'https://downloads.ioncube.com/loader_downloads/ioncube_loaders_mac_x86-64.tar.gz',
             'file_extension' => self::TAR_GZ_FILE_EXTENSION,
             'packaged_directory' => 'ioncube',
             'default' => false,

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -696,25 +696,25 @@ if (is_dir(VALET_HOME_PATH)) {
             throw new Exception('Mode not found. Available modes: '.implode(', ', $modes));
         }
 
-        if (PeclCustom::isInstalled('ioncube_loader_dar') === false) {
+        if (PeclCustom::isInstalled('ioncube_loader_mac') === false) {
             info('[PECL-CUSTOM] Ioncube loader not found, installing...');
-            PeclCustom::installExtension('ioncube_loader_dar');
+            PeclCustom::installExtension('ioncube_loader_mac');
         }
 
-        if (PeclCustom::isEnabled('ioncube_loader_dar') === false && ($mode === 'on' || $mode === 'enable')) {
-            info("[PECL-CUSTOM] Enabling ioncube_loader_dar extension");
-            PeclCustom::enableExtension('ioncube_loader_dar');
+        if (PeclCustom::isEnabled('ioncube_loader_mac') === false && ($mode === 'on' || $mode === 'enable')) {
+            info("[PECL-CUSTOM] Enabling ioncube_loader_mac extension");
+            PeclCustom::enableExtension('ioncube_loader_mac');
             PhpFpm::restart();
         } elseif ($mode === 'on' || $mode === 'enable') {
-            info("[PECL-CUSTOM] ioncube_loader_dar extension is already installed");
+            info("[PECL-CUSTOM] ioncube_loader_mac extension is already installed");
         }
 
-        if (PeclCustom::isEnabled('ioncube_loader_dar') === true && ($mode === 'off' || $mode === 'disable')) {
-            info("[PECL-CUSTOM] Disabling ioncube_loader_dar extension");
-            PeclCustom::disable('ioncube_loader_dar');
+        if (PeclCustom::isEnabled('ioncube_loader_mac') === true && ($mode === 'off' || $mode === 'disable')) {
+            info("[PECL-CUSTOM] Disabling ioncube_loader_mac extension");
+            PeclCustom::disable('ioncube_loader_mac');
             PhpFpm::restart();
         } elseif ($mode === 'off' || $mode === 'disable') {
-            info("[PECL-CUSTOM] ioncube_loader_dar extension is already uninstalled");
+            info("[PECL-CUSTOM] ioncube_loader_mac extension is already uninstalled");
         }
     })->descriptions('Enable / disable ioncube');
 


### PR DESCRIPTION
- [X] There is an issue ticket which accompanies my PR: https://github.com/weprovide/valet-plus/issues/582
- [X] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [X] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [X] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `ioncube-support-for-php-74`:**  
Because this is a Bug Fix which is Backwards Compatible.  

**Changelog entry:**  
- Add PHP 7.4 ioncube support and change the download link from dar to mac specific tar archives.