### PR TITLE
Github Action: Remove default PHP and upgrade to valet-php@7.4

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -99,6 +99,7 @@ jobs:
       - name: '[NGINX] Sudo nginx -t'
         run: |
           sudo nginx -t
+          tail /usr/local/var/log/nginx/error.log
           
       # Check which brew services and ports are used after running after NGINX start check.
       - name: '[NGINX] Brew services list'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -25,6 +25,12 @@ jobs:
       # Check which services is running on the Mac OS image
       - name: '[Ports] Port check'
         run: sudo lsof -PiTCP -sTCP:LISTEN
+        
+      # For the Valet+ CI/CD remove the default brew nginx.
+      # On a local installation one might choose to keep his/her default brew nginx installation.
+      - name: '[INSTALL] Brew uninstall nginx'
+        run: |
+          brew uninstall nginx
 
       # Update brew formulas to latest version
       - name: '[INSTALL] Brew update'
@@ -36,18 +42,6 @@ jobs:
           
         # List running services
       - name: '[INSTALL] Brew services list - before restart'
-        run: |
-          brew services list
-          sudo brew services list
-          
-      # Test to start nginx as sudo
-      - name: '[INSTALL] Brew restart nginx'
-        run: |
-          brew list nginx
-          sudo brew services restart nginx
-          
-        # List running services
-      - name: '[INSTALL] Brew services list - after restart'
         run: |
           brew services list
           sudo brew services list

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -40,6 +40,7 @@ jobs:
       # For the Valet+ CI/CD remove the default nginx installation. Instead use valet install to install nginx.
       - name: '[INSTALL] Brew uninstall nginx'
         run: |
+          brew upgrade
           brew list nginx
           brew uninstall --ignore-dependencies nginx
           rm -rf /usr/local/etc/nginx

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -31,6 +31,11 @@ jobs:
       - name: '[INSTALL] Brew uninstall php'
         run: |
           brew uninstall --ignore-dependencies php
+        
+      # For the Valet+ CI/CD unlink the default brew PHP.
+      - name: '[INSTALL] Brew unlink php'
+        run: |
+          brew unlink php
 
       # Install the valet-php brew tap.
       - name: '[INSTALL] Brew tap henkrehost/php'
@@ -39,12 +44,12 @@ jobs:
 
       # Remove 2to3 to ensure python installation: https://github.com/weprovide/valet-plus/issues/558
       # Install the default PHP version (currently: valet-php@7.4).
-      - name: '[INSTALL] Brew install valet-php@7.2'
+      - name: '[INSTALL] Brew install valet-php@7.4'
         run: |
           rm /usr/local/bin/2to3
           brew install valet-php@7.4 --build-from-source
 
-      # Link valet-php@7.2 as default php binary.
+      # Link valet-php@7.4 as default php binary.
       - name: '[INSTALL] Brew link valet-php@7.4'
         run: |
           brew link valet-php@7.4 --force

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       
       # Check which services is running on the Mac OS image
       - name: '[MAC OS Image] Port check'
-        run: sudo lsof -nP -i4TCP:80 | grep LISTEN
+        run: sudo netstat -lpn
 
       # Valet install command test cases
       - name: '[INSTALL] Brew update'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -81,6 +81,7 @@ jobs:
       # Check which brew services which are running after Valet install.
       - name: '[INSTALL] Brew services list'
         run: |
+         sudo brew services list
          brew services list
 
       # Nginx test cases

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -25,11 +25,6 @@ jobs:
       # Valet install command test cases
       - name: '[INSTALL] Brew update'
         run: brew update
-        
-      # For the Valet+ CI/CD unlink the default brew PHP.
-      - name: '[INSTALL] Brew unlink php'
-        run: |
-          brew unlink php
 
       # For the Valet+ CI/CD remove the default brew PHP. Instead use valet-php.
       # On a local installation one might choose to keep his/her default brew PHP installation.
@@ -52,7 +47,8 @@ jobs:
       # Link valet-php@7.4 as default php binary.
       - name: '[INSTALL] Brew link valet-php@7.4'
         run: |
-          brew link valet-php@7.4 --force
+          brew link --overwrite --dry-run valet-php@7.4
+          brew link --overwrite valet-php@7.4
           php -v | grep 7.4
 
       # Since the Github actions CI/CD image comes with composer pre-installed there is no need to install composer.

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -36,6 +36,12 @@ jobs:
         run: |
           brew unlink php
           brew uninstall --ignore-dependencies php
+          
+      # TEST: For the Valet+ CI/CD install nginx from source.
+      - name: '[INSTALL] Brew install nginx'
+        run: |
+          brew list nginx
+          brew install nginx --build-from-source
 
       # Install the valet-php brew tap.
       - name: '[INSTALL] Brew tap henkrehost/php'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -77,6 +77,11 @@ jobs:
       - name: '[INSTALL] Valet install'
         run: |
           ./valet install
+          
+      # Check which brew services which are running after Valet install.
+      - name: '[INSTALL] Brew services list'
+        run: |
+         brew services list
 
       # Nginx test cases
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       
       # Check which services is running on the Mac OS image
       - name: '[MAC OS Image] Port check'
-        run: sudo netstat -lpn
+        run: sudo lsof -PiTCP -sTCP:LISTEN
 
       # Valet install command test cases
       - name: '[INSTALL] Brew update'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -92,7 +92,7 @@ jobs:
       
       # Start nginx server
       - name: '[NGINX] brew services start nginx'
-      - run: |
+        run: |
          brew services start nginx
 
       # Check if nginx was able to start correctly.

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -23,12 +23,16 @@ jobs:
       - uses: actions/checkout@v2
       
       # Check which services is running on the Mac OS image
-      - name: '[MAC OS Image] Port check'
+      - name: '[Ports] Port check'
         run: sudo lsof -PiTCP -sTCP:LISTEN
 
-      # Valet install command test cases
+      # Update brew formulas to latest version
       - name: '[INSTALL] Brew update'
         run: brew update
+        
+      # Upgrade preinstalled brew packages to latest version
+      - name: '[INSTALL] Brew upgrade'
+        run: brew upgrade
 
       # For the Valet+ CI/CD remove the default brew PHP. Instead use valet-php.
       # On a local installation one might choose to keep his/her default brew PHP installation.

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -48,7 +48,7 @@ jobs:
       # Link valet-php@7.4 as default php binary.
       - name: '[INSTALL] Brew link valet-php@7.4'
         run: |
-          brew link valet-php@7.4 --force
+          brew link valet-php@7.4 --overwrite --force
           php -v | grep 7.4
 
       # Since the Github actions CI/CD image comes with composer pre-installed there is no need to install composer.

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -30,6 +30,7 @@ jobs:
       # On a local installation one might choose to keep his/her default brew PHP installation.
       - name: '[INSTALL] Brew uninstall php'
         run: |
+          brew unlink php
           brew uninstall --ignore-dependencies php
 
       # Install the valet-php brew tap.
@@ -47,8 +48,7 @@ jobs:
       # Link valet-php@7.4 as default php binary.
       - name: '[INSTALL] Brew link valet-php@7.4'
         run: |
-          brew link --overwrite --force --dry-run valet-php@7.4
-          brew link --overwrite --force valet-php@7.4
+          brew link valet-php@7.4 --force
           php -v | grep 7.4
 
       # Since the Github actions CI/CD image comes with composer pre-installed there is no need to install composer.

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -37,11 +37,11 @@ jobs:
           brew unlink php
           brew uninstall --ignore-dependencies php
           
-      # TEST: For the Valet+ CI/CD install nginx from source.
-      - name: '[INSTALL] Brew install nginx'
+      # For the Valet+ CI/CD remove the default nginx installation. Instead use valet install to install nginx.
+      - name: '[INSTALL] Brew uninstall nginx'
         run: |
           brew list nginx
-          brew install nginx --build-from-source
+          brew uninstall --ignore-dependencies nginx
 
       # Install the valet-php brew tap.
       - name: '[INSTALL] Brew tap henkrehost/php'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -37,15 +37,23 @@ jobs:
           brew unlink php
           brew uninstall --ignore-dependencies php
           
-      # Test to start nginx
-      - name: '[INSTALL] Brew test nginx'
+        # List running services
+      - name: '[INSTALL] Brew services list - before restart'
+        run: |
+          brew services list
+          sudo brew services list
+          
+      # Test to start nginx as sudo
+      - name: '[INSTALL] Brew restart nginx'
         run: |
           brew list nginx
-          sudo brew services list
-          brew services restart --all
-          sudo brew services restart --all
-          sudo brew services list
+          sudo brew services restart nginx
+          
+        # List running services
+      - name: '[INSTALL] Brew services list - after restart'
+        run: |
           brew services list
+          sudo brew services list
 
       # Install the valet-php brew tap.
       - name: '[INSTALL] Brew tap henkrehost/php'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -25,17 +25,17 @@ jobs:
       # Valet install command test cases
       - name: '[INSTALL] Brew update'
         run: brew update
+        
+      # For the Valet+ CI/CD unlink the default brew PHP.
+      - name: '[INSTALL] Brew unlink php'
+        run: |
+          brew unlink php
 
       # For the Valet+ CI/CD remove the default brew PHP. Instead use valet-php.
       # On a local installation one might choose to keep his/her default brew PHP installation.
       - name: '[INSTALL] Brew uninstall php'
         run: |
           brew uninstall --ignore-dependencies php
-        
-      # For the Valet+ CI/CD unlink the default brew PHP.
-      - name: '[INSTALL] Brew unlink php'
-        run: |
-          brew unlink php
 
       # Install the valet-php brew tap.
       - name: '[INSTALL] Brew tap henkrehost/php'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -89,12 +89,23 @@ jobs:
          brew services list
 
       # Nginx test cases
+      
+      # Start nginx server
+      - name: '[NGINX] brew services start nginx'
+      - run: |
+         brew services start nginx
 
       # Check if nginx was able to start correctly.
       - name: '[NGINX] Sudo nginx -t'
         run: |
           sudo nginx -t
-          brew services start nginx
+          
+      # Check which brew services and ports are used after running after NGINX start check.
+      - name: '[NGINX] Brew services list'
+        run: |
+         sudo brew services list
+         brew services list
+         sudo lsof -PiTCP -sTCP:LISTEN
           
       # Check if the Valet+ localhost page is reachable.
       - name: '[NGINX] Check local host'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -104,6 +104,17 @@ jobs:
          brew services list
 
       # Nginx test cases
+      
+      # Start nginx server
+      - name: '[NGINX] brew services start nginx'
+        run: |
+         sudo brew services start nginx  
+         
+      # Check which brew services which are running after Valet install.
+      - name: '[NGINX] Brew services list'
+        run: |
+         sudo brew services list
+         brew services list
 
       # Check if nginx was able to start correctly.
       - name: '[NGINX] Sudo nginx -t'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -90,6 +90,8 @@ jobs:
       - name: '[NGINX] Sudo nginx -t'
         run: |
           sudo nginx -t
+          brew services start nginx
+          
       # Check if the Valet+ localhost page is reachable.
       - name: '[NGINX] Check local host'
         run: |

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       
       # Check which services is running on the Mac OS image
       - name: '[MAC OS Image] Port check'
-        run: sudo lsof -nP -iTCP:80 | grep LISTEN
+        run: sudo lsof -nP -i4TCP:80 | grep LISTEN
 
       # Valet install command test cases
       - name: '[INSTALL] Brew update'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      
+      # Check which services is running on the Mac OS image
+      - name: '[MAC OS Image] Port check'
+        run: sudo lsof -nP -iTCP:80 | grep LISTEN
 
       # Valet install command test cases
       - name: '[INSTALL] Brew update'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -33,13 +33,6 @@ jobs:
       # Upgrade preinstalled brew packages to latest version
       - name: '[INSTALL] Brew upgrade'
         run: brew upgrade
-
-      # For the Valet+ CI/CD remove the default brew PHP. Instead use valet-php.
-      # On a local installation one might choose to keep his/her default brew PHP installation.
-      - name: '[INSTALL] Brew uninstall php'
-        run: |
-          brew unlink php
-          brew uninstall --ignore-dependencies php
           
         # List running services
       - name: '[INSTALL] Brew services list - before restart'
@@ -111,11 +104,6 @@ jobs:
          brew services list
 
       # Nginx test cases
-      
-      # Start nginx server
-      - name: '[NGINX] brew services start nginx'
-        run: |
-         brew services start nginx
 
       # Check if nginx was able to start correctly.
       - name: '[NGINX] Sudo nginx -t'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -39,12 +39,6 @@ jobs:
       # Upgrade preinstalled brew packages to latest version
       - name: '[INSTALL] Brew upgrade'
         run: brew upgrade
-          
-        # List running services
-      - name: '[INSTALL] Brew services list - before restart'
-        run: |
-          brew services list
-          sudo brew services list
 
       # Install the valet-php brew tap.
       - name: '[INSTALL] Brew tap henkrehost/php'
@@ -98,14 +92,8 @@ jobs:
          brew services list
 
       # Nginx test cases
-         
-      # Check which brew services which are running after Valet install.
-      - name: '[NGINX] Brew services list'
-        run: |
-         sudo brew services list
-         brew services list
 
-      # Check if nginx was able to start correctly.
+      # Check if nginx syntax is correct.
       - name: '[NGINX] Sudo nginx -t'
         run: |
           sudo nginx -t
@@ -117,7 +105,7 @@ jobs:
           tail /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
           
       # Check if the Valet+ localhost page is reachable.
-      - name: '[NGINX] Check local host'
+      - name: '[NGINX] Check localhost'
         run: |
           curl 127.0.0.1 | grep "Valet - Not Found"
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     # Build on Catalina and later Big Sur (Not public released yet: https://github.com/actions/virtual-environments/issues/2486)
     strategy:
       matrix:
-          os: [macos-10.15]
+          os: [macos-11]
     runs-on: ${{matrix.os}}
 
     # A workflow run is made up of one or more jobs that can run sequentially or in parallel# All actions starting with [INSTALL] are installation instructions that can be found

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -104,11 +104,6 @@ jobs:
          brew services list
 
       # Nginx test cases
-      
-      # Start nginx server
-      - name: '[NGINX] brew services start nginx'
-        run: |
-         sudo brew services start nginx  
          
       # Check which brew services which are running after Valet install.
       - name: '[NGINX] Brew services list'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -37,13 +37,15 @@ jobs:
           brew unlink php
           brew uninstall --ignore-dependencies php
           
-      # For the Valet+ CI/CD remove the default nginx installation. Instead use valet install to install nginx.
-      - name: '[INSTALL] Brew uninstall nginx'
+      # Test to start nginx
+      - name: '[INSTALL] Brew test nginx'
         run: |
-          brew upgrade
           brew list nginx
-          brew uninstall --ignore-dependencies nginx
-          rm -rf /usr/local/etc/nginx
+          sudo brew services list
+          brew services restart --all
+          sudo brew services restart --all
+          sudo brew services list
+          brew services list
 
       # Install the valet-php brew tap.
       - name: '[INSTALL] Brew tap henkrehost/php'
@@ -107,15 +109,12 @@ jobs:
       - name: '[NGINX] Sudo nginx -t'
         run: |
           sudo nginx -t
-          tail /usr/local/var/log/nginx/error.log
           
-      # Check which brew services and ports are used after running after NGINX start check.
-      - name: '[NGINX] Brew services list'
+       # Check if nginx has any known errors.
+      - name: '[NGINX] Show nginx error log'
         run: |
-         sudo brew services list
-         brew services list
-         tail /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
-         sudo lsof -PiTCP -sTCP:LISTEN
+          tail /usr/local/var/log/nginx/error.log
+          tail /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
           
       # Check if the Valet+ localhost page is reachable.
       - name: '[NGINX] Check local host'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -47,7 +47,7 @@ jobs:
       # Link valet-php@7.4 as default php binary.
       - name: '[INSTALL] Brew link valet-php@7.4'
         run: |
-          brew link --overwrite --dry-run valet-php@7.4
+          brew link --overwrite --force --dry-run valet-php@7.4
           brew link --overwrite --force valet-php@7.4
           php -v | grep 7.4
 

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       
       # Check which services is running on the Mac OS image
-      - name: '[Ports] Port check'
+      - name: '[Port] Port check'
         run: sudo lsof -PiTCP -sTCP:LISTEN
         
       # For the Valet+ CI/CD remove the default brew nginx.

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -30,7 +30,7 @@ jobs:
       # On a local installation one might choose to keep his/her default brew PHP installation.
       - name: '[INSTALL] Brew uninstall php'
         run: |
-          brew uninstall php
+          brew uninstall --ignore-dependencies php
 
       # Install the valet-php brew tap.
       - name: '[INSTALL] Brew tap henkrehost/php'
@@ -38,17 +38,17 @@ jobs:
           brew tap henkrehorst/php
 
       # Remove 2to3 to ensure python installation: https://github.com/weprovide/valet-plus/issues/558
-      # Install the default PHP version (currently: valet-php@7.2).
+      # Install the default PHP version (currently: valet-php@7.4).
       - name: '[INSTALL] Brew install valet-php@7.2'
         run: |
           rm /usr/local/bin/2to3
-          brew install valet-php@7.3 --build-from-source
+          brew install valet-php@7.4 --build-from-source
 
       # Link valet-php@7.2 as default php binary.
-      - name: '[INSTALL] Brew link valet-php@7.2'
+      - name: '[INSTALL] Brew link valet-php@7.4'
         run: |
-          brew link valet-php@7.3 --force
-          php -v | grep 7.3
+          brew link valet-php@7.4 --force
+          php -v | grep 7.4
 
       # Since the Github actions CI/CD image comes with composer pre-installed there is no need to install composer.
       # However the image might change in the future. To ensure installation over several images an IF ELSE used.

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           brew list nginx
           brew uninstall --ignore-dependencies nginx
+          rm -rf /usr/local/etc/nginx
 
       # Install the valet-php brew tap.
       - name: '[INSTALL] Brew tap henkrehost/php'

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -105,6 +105,7 @@ jobs:
         run: |
          sudo brew services list
          brew services list
+         tail /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
          sudo lsof -PiTCP -sTCP:LISTEN
           
       # Check if the Valet+ localhost page is reachable.

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -48,7 +48,7 @@ jobs:
       - name: '[INSTALL] Brew link valet-php@7.4'
         run: |
           brew link --overwrite --dry-run valet-php@7.4
-          brew link --overwrite valet-php@7.4
+          brew link --overwrite --force valet-php@7.4
           php -v | grep 7.4
 
       # Since the Github actions CI/CD image comes with composer pre-installed there is no need to install composer.


### PR DESCRIPTION
The current test pipeline seems to fail since the default PHP version of the image is not uninstalled correct. This pull request also updates the test pipeline to use valet-php@7.4 which is the recommended version since Valet+ 2.3.0

- [ ] There is an issue ticket which accompanies my PR: <Your-Issue-Link>.
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `<YOUR_TARGET_BRANCH>`:**  
Bugfix of Github actions which seems to fail.

**Changelog entry:**  
- Github Action Workflow: Remove default version of PHP, even if there is dependencies. 
- Github Action Workflow: Upgrade test to use valet-php@7.4 as default.
