### PR TITLE
Fix problem with Non-static method getBrewPath()

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -942,11 +942,11 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('logs [service]', function ($service) {
         $logs = [
             'php' => '$HOME/.valet/Log/php.log',
-            'php-fpm' => \Valet\Architecture::getBrewPath() . '/var/log/php-fpm.log',
+            'php-fpm' => Architecture::getBrewPath() . '/var/log/php-fpm.log',
             'nginx' => '$HOME/.valet/Log/nginx-error.log',
             'mysql' => '$HOME/.valet/Log/mysql.log',
-            'mailhog' => \Valet\Architecture::getBrewPath() . '/var/log/mailhog.log',
-            'redis' => \Valet\Architecture::getBrewPath() . '/var/log/redis.log',
+            'mailhog' => Architecture::getBrewPath() . '/var/log/mailhog.log',
+            'redis' => Architecture::getBrewPath() . '/var/log/redis.log',
         ];
 
         if (!isset($logs[$service])) {

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -940,13 +940,14 @@ if (is_dir(VALET_HOME_PATH)) {
     })->descriptions('Display all of the registered Valet rewrites');
 
     $app->command('logs [service]', function ($service) {
+        $brewPath = Architecture::getBrewPath();
         $logs = [
             'php' => '$HOME/.valet/Log/php.log',
-            'php-fpm' => Architecture::getBrewPath() . '/var/log/php-fpm.log',
+            'php-fpm' => $brewPath . '/var/log/php-fpm.log',
             'nginx' => '$HOME/.valet/Log/nginx-error.log',
             'mysql' => '$HOME/.valet/Log/mysql.log',
-            'mailhog' => Architecture::getBrewPath() . '/var/log/mailhog.log',
-            'redis' => Architecture::getBrewPath() . '/var/log/redis.log',
+            'mailhog' => $brewPath . '/var/log/mailhog.log',
+            'redis' => $brewPath . '/var/log/redis.log',
         ];
 
         if (!isset($logs[$service])) {


### PR DESCRIPTION
This method is not static, and not should called as is

- [x] There is an issue ticket which accompanies my PR: [Bug: valet logs {service} ](https://github.com/weprovide/valet-plus/issues/592).
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `2.x`:**  
Because this is a Bug Fix which is Backwards Compatible.  
Because this is a Feature which is not Backwards Compatible.  
Because this is a Deprecation which is Backwards Compatible.  
etc...

**Changelog entry:**  
Short description of your work as explained by: [Keep A Changelog](https://keepachangelog.com).
Fix calls for non static methods in command: `valet logs {service}`
