### PR TITLE
Added support for PHP 8.1 and improved switching between versions

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -49,6 +49,20 @@ class Brew
     }
 
     /**
+     * Get the aliased formula version from Homebrew.
+     */
+    public function determineAliasedVersion($formula)
+    {
+        $details = json_decode($this->cli->runAsUser("brew info $formula --json"));
+
+        if (!empty($details[0]->aliases[0])) {
+            return $details[0]->aliases[0];
+        }
+
+        return 'ERROR - NO BREW ALIAS FOUND';
+    }
+
+    /**
      * Determine if a compatible nginx version is Homebrewed.
      *
      * @return bool

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -26,12 +26,18 @@ class Brew
      * Determine if the given formula is installed.
      *
      * @param  string $formula
+     * @param  bool $fullName whether full formula name is given or not
      * @return bool
      */
-    public function installed($formula)
+    public function installed($formula, $fullName = true)
     {
 //        var_dump('brew list --formula | grep ' . $formula);
-        $formulae = $this->cli->runAsUser('brew list --formula | grep ' . $formula);
+        if ($fullName) {
+            $formulae = $this->cli->runAsUser('brew list --formula --full-name | grep ' . $formula);
+        } else {
+            $formulae = $this->cli->runAsUser('brew list --formula | grep ' . $formula);
+        }
+
         if (in_array($formula, explode(PHP_EOL, $formulae))) {
             $installed = trim($this->cli->runAsUser('brew info ' . $formula . ' | grep "Not installed"'));
             if ($installed === "") {
@@ -196,7 +202,7 @@ class Brew
         $services = is_array($services) ? $services : func_get_args();
 
         foreach ($services as $service) {
-            if ($this->installed($service)) {
+            if ($this->installed($service, false)) {
                 info('[' . $service . '] Restarting');
 
                 $this->cli->quietly('sudo brew services stop ' . $service);
@@ -215,9 +221,8 @@ class Brew
         $services = is_array($services) ? $services : func_get_args();
 
         foreach ($services as $service) {
-            if ($this->installed($service)) {
+            if ($this->installed($service, false)) {
                 info('[' . $service . '] Stopping');
-
                 $this->cli->quietly('sudo brew services stop ' . $service);
             }
         }

--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -43,6 +43,7 @@ class Pecl extends AbstractPecl
      */
     const EXTENSIONS = [
         self::XDEBUG_EXTENSION => [
+            '8.1' => '3.0.4',
             '8.0' => '3.0.4',
             '7.4' => '3.0.4',
             '7.3' => '3.0.4',
@@ -54,6 +55,7 @@ class Pecl extends AbstractPecl
             'extension_type' => self::ZEND_EXTENSION_TYPE
         ],
         self::APCU_EXTENSION => [
+            '8.1' => '5.1.21',
             '7.3' => '5.1.17',
             '7.2' => '5.1.17',
             '7.1' => '5.1.17',
@@ -62,6 +64,7 @@ class Pecl extends AbstractPecl
             'extension_type' => self::NORMAL_EXTENSION_TYPE
         ],
         self::GEOIP_EXTENSION => [
+            '8.1' => false, //todo; will probably be 1.1.2
             '8.0' => false, //todo; will probably be 1.1.2
             '7.4' => '1.1.1',
             '7.3' => '1.1.1',

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -15,7 +15,7 @@ class PhpFpm
     const PHP_V73_VERSION = '7.3';
     const PHP_V74_VERSION = '7.4';
     const PHP_V80_VERSION = '8.0';
-//    const PHP_V81_VERSION = '8.1';
+    const PHP_V81_VERSION = '8.1';
 
     const SUPPORTED_PHP_FORMULAE = [
 //        self::PHP_V56_VERSION => self::PHP_FORMULA_NAME . self::PHP_V56_VERSION,
@@ -25,7 +25,7 @@ class PhpFpm
         self::PHP_V73_VERSION => self::PHP_FORMULA_NAME .'@'. self::PHP_V73_VERSION,
         self::PHP_V74_VERSION => self::PHP_FORMULA_NAME .'@'. self::PHP_V74_VERSION,
         self::PHP_V80_VERSION => self::PHP_FORMULA_NAME .'@'. self::PHP_V80_VERSION,
-//        self::PHP_V81_VERSION => self::PHP_FORMULA_NAME
+        self::PHP_V81_VERSION => self::PHP_FORMULA_NAME
     ];
 
     const EOL_PHP_VERSIONS = [
@@ -147,7 +147,7 @@ class PhpFpm
     {
         $brewPath = $this->architecture->getBrewPath();
         $confLookup = [
-//            self::PHP_V81_VERSION => $brewPath . self::LOCAL_PHP_FOLDER . '8.1/php-fpm.d/www.conf',
+            self::PHP_V81_VERSION => $brewPath . self::LOCAL_PHP_FOLDER . '8.1/php-fpm.d/www.conf',
             self::PHP_V80_VERSION => $brewPath . self::LOCAL_PHP_FOLDER . '8.0/php-fpm.d/www.conf',
             self::PHP_V74_VERSION => $brewPath . self::LOCAL_PHP_FOLDER . '7.4/php-fpm.d/www.conf',
             self::PHP_V73_VERSION => $brewPath . self::LOCAL_PHP_FOLDER . '7.3/php-fpm.d/www.conf',

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -513,7 +513,7 @@ class PhpFpm
     public function hasInstalledPhp()
     {
         foreach (self::SUPPORTED_PHP_FORMULAE as $version => $brewName) {
-            if ($this->brew->installed(self::PHP_FORMULA_PREFIX.self::PHP_FORMULA_PREFIX.$brewName)) {
+            if ($this->brew->installed(self::PHP_FORMULA_PREFIX . $brewName)) {
                 return true;
             }
         }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -220,7 +220,9 @@ class PhpFpm
         $this->stop();
         $this->install();
 
-        info("Valet is now using " . self::SUPPORTED_PHP_FORMULAE[$version]);
+        $version = self::SUPPORTED_PHP_FORMULAE[$version];
+        $newVersion = $version === 'php' ? $this->brew->determineAliasedVersion($version) : $version;
+        info("Valet is now using " . $newVersion);
     }
 
     /**


### PR DESCRIPTION
- [x] There is an issue ticket which accompanies my PR: #600.
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `release/2.4`:**  
Because this PR depends on code only available in that branch.

**Changelog entry:**  
### Added
- Support for PHP 8.1
- Used a few existing methods from Laravel Valet fork

### Changed
- Improved switching between PHP versions after changes in Brew taps.
- Take into account different formula names like `php` or `php@7.4`. 
- Check if PHP is linked before trying to unlink.

I am not very happy with my changes made inside `\Valet\Brew::installed` method. Maybe there is a better option for checking if a formula is installed. And maybe it would be easier not to use the full PHP formula name like 'shivammathur/php/php@7.3'.
