### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/cli/Valet/Pecl.php
+++ b/cli/Valet/Pecl.php
@@ -43,6 +43,7 @@ class Pecl extends AbstractPecl
      */
     const EXTENSIONS = [
         self::XDEBUG_EXTENSION => [
+            '8.1' => '3.0.4',
             '8.0' => '3.0.4',
             '7.4' => '3.0.4',
             '7.3' => '3.0.4',
@@ -62,7 +63,8 @@ class Pecl extends AbstractPecl
             'extension_type' => self::NORMAL_EXTENSION_TYPE
         ],
         self::GEOIP_EXTENSION => [
-            '8.0' => false, //todo; will probably be 1.1.2
+            '8.1' => false, //todo; will probably be 1.1.2
+            '8.0' => false, 
             '7.4' => '1.1.1',
             '7.3' => '1.1.1',
             '7.2' => '1.1.1',

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -14,6 +14,7 @@ class PhpFpm
     const PHP_V73_VERSION = '7.3';
     const PHP_V74_VERSION = '7.4';
     const PHP_V80_VERSION = '8.0';
+    const PHP_V81_VERSION = '8.1';
 
     const SUPPORTED_PHP_FORMULAE = [
         self::PHP_V56_VERSION => self::PHP_FORMULA_NAME . self::PHP_V56_VERSION,
@@ -22,7 +23,8 @@ class PhpFpm
         self::PHP_V72_VERSION => self::PHP_FORMULA_NAME . self::PHP_V72_VERSION,
         self::PHP_V73_VERSION => self::PHP_FORMULA_NAME . self::PHP_V73_VERSION,
         self::PHP_V74_VERSION => self::PHP_FORMULA_NAME . self::PHP_V74_VERSION,
-        self::PHP_V80_VERSION => self::PHP_FORMULA_NAME . self::PHP_V80_VERSION
+        self::PHP_V80_VERSION => self::PHP_FORMULA_NAME . self::PHP_V80_VERSION,
+        self::PHP_V81_VERSION => self::PHP_FORMULA_NAME . self::PHP_V81_VERSION
     ];
 
     const EOL_PHP_VERSIONS = [
@@ -135,6 +137,7 @@ class PhpFpm
     {
         $brewPath = $this->architecture->getBrewPath();
         $confLookup = [
+            self::PHP_V81_VERSION => $brewPath . self::LOCAL_PHP_FOLDER . '8.1/php-fpm.d/www.conf',
             self::PHP_V80_VERSION => $brewPath . self::LOCAL_PHP_FOLDER . '8.0/php-fpm.d/www.conf',
             self::PHP_V74_VERSION => $brewPath . self::LOCAL_PHP_FOLDER . '7.4/php-fpm.d/www.conf',
             self::PHP_V73_VERSION => $brewPath . self::LOCAL_PHP_FOLDER . '7.3/php-fpm.d/www.conf',
@@ -482,7 +485,8 @@ class PhpFpm
         $versions = self::SUPPORTED_PHP_FORMULAE;
 
         foreach ($versions as $version => $brewname) {
-            if (strpos($resolvedPath, '/' . $brewname . '/') !== false) {
+            if (strpos($resolvedPath, '/php@' . $version . '/') !== false ||
+                strpos($resolvedPath, '/' . $version . '') !== false) {
                 return $version;
             }
         }


### PR DESCRIPTION
- [x] There is an issue ticket which accompanies my PR: .
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `2.x`:**  
Because this is a Bug Fix which is Backwards Compatible.  
Because this is a Feature which is not Backwards Compatible.  
Because this is a Deprecation which is Backwards Compatible.  
etc...

**Changelog entry:**  
Implemented php 8.1 support for current version as had a requirement for this and didn't see a valid fix after testing through previous issues.
