### PR TITLE
Fix bedrockvaletdriver

### DIFF
--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -51,13 +51,11 @@ class BedrockValetDriver extends BasicValetDriver
 
         $_SERVER['PHP_SELF'] = $uri;
 
-        if (strpos($uri, '/wp/') === 0) {
-            return is_dir($sitePath.'/web'.$uri)
-                            ? $sitePath.'/web'.$this->forceTrailingSlash($uri).'/index.php'
-                            : $sitePath.'/web'.$uri;
-        }
-
-        return $sitePath.'/web/index.php';
+        return parent::frontControllerPath(
+            $sitePath . '/web',
+            $siteName,
+            $this->forceTrailingSlash($uri)
+        );
     }
 
     /**

--- a/cli/drivers/BedrockValetDriver.php
+++ b/cli/drivers/BedrockValetDriver.php
@@ -50,6 +50,8 @@ class BedrockValetDriver extends BasicValetDriver
         $this->loadServerEnvironmentVariables($sitePath, $siteName);
 
         $_SERVER['PHP_SELF'] = $uri;
+        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
+        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
 
         return parent::frontControllerPath(
             $sitePath . '/web',


### PR DESCRIPTION
- [x] There is an issue ticket which accompanies my PR: #613
- [x] I have followed the [guidelines for contributing](https://github.com/weprovide/valet-plus/blob/master/CONTRIBUTING.md).
- [x] I have checked that there aren't other open [pull requests](https://github.com/weprovide/valet-plus/pulls) for the same issue ticket.
- [x] I have formatted my code with the [PSR-2](http://www.php-fig.org/psr/psr-2/) coding style before submitting my PR.
-----

**I have read the contribution guidelines and am targeting the branch `<YOUR_TARGET_BRANCH>`:**  
Because this is a Bug Fix which is Backwards Compatible.  
Because this is a Feature which is not Backwards Compatible.  
Because this is a Deprecation which is Backwards Compatible.  
etc...

**Changelog entry:**  
### Changed
Fix bedrockvaletdriver to use parent frontcontroller method for custom wp-admin urls

Short description of your work as explained by: [Keep A Changelog](https://keepachangelog.com).

I'd experienced an issue with the bedrock valet driver for awhile specific to the custom wp-admin route provided by plugins, like the hidden backend feature in iThemes security.

I finally dug into it and found that the driver is out of sync with the WordPress driver and had a few headers missing from the other drivers. So I tested updating it to match the WordPress driver and it fixed my problem.

This uses the built in routing available instead of assuming that the folder has an index.php or is part of WordPress core.

If accepted please kindly add [hacktoberfest-accepted] label too, thanks.