### PR TITLE
Add db password show (#555)

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 use function Valet\info;
+use function Valet\output;
 use function Valet\table;
 use function Valet\warning;
 
@@ -408,7 +409,7 @@ if (is_dir(VALET_HOME_PATH)) {
      * Database services and commands.
      */
     $app
-        ->command('db [run] [name] [optional] [-y|--yes]', function ($input, $output, $run, $name, $optional) {
+        ->command('db [run] [name] [optional] [-y|--yes] [-s|--show]', function ($input, $output, $run, $name, $optional) {
             $helper   = $this->getHelperSet()->get('question');
             $defaults = $input->getOptions();
 
@@ -524,7 +525,17 @@ if (is_dir(VALET_HOME_PATH)) {
             }
 
             if ($run === 'pwd' || $run === 'password') {
-                if (!$name || !$optional) {
+                if ($defaults['show']) {
+                    $question = new ConfirmationQuestion('Are you sure you want to show the configured root password? [y/N] ', false);
+                    if ($defaults['yes'] || $helper->ask($input, $output, $question)) {
+                        info('Current configured password for root user: ' . Mysql::getConfigRootPassword());
+                        output('<fg=yellow>Please note this is the password as configured in Valet+!</>');
+                    }
+
+                    return;
+                }
+
+                if ($name === null || $optional === null) {
                     throw new Exception('Missing arguments to change root user password. Use: "valet db pwd <old> <new>"');
                 }
 


### PR DESCRIPTION
As requested in #555 this PR adds a way to show the current configured root password. As configured in Valet+, there is no way to retrieve the actual configured root password of MySQL.
If setting the root password fails, you will now get some information on what to do next.

![Screenshot 2024-02-16 at 16 03 58](https://github.com/weprovide/valet-plus/assets/19824986/d0e15696-dc08-4056-b6a7-efbb4fca6343)
![Screenshot 2024-02-16 at 16 04 31](https://github.com/weprovide/valet-plus/assets/19824986/61956655-2b7a-46a5-abee-d1b137beee96)
