### PR TITLE
Add proxy for Drush commands

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -702,6 +702,10 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('configure', function () {
         DriverConfigurator::configure();
     })->descriptions('Configure application with know framework settings');
+
+    $app->command('which-uri', function () {
+        return output( Site::domain(null));
+    })->descriptions('Displays the URL of the current site');
 }
 
 /**

--- a/valet-plus
+++ b/valet-plus
@@ -182,6 +182,20 @@ then
 
     exit
 
+# Proxy Drush commands with the "php" executable on the isolated site
+elif [[ "$1" = "drush" ]]
+then
+    if [[ $2 == *"--site="* ]]; then
+        SITE=${2#*=}
+        $(php "$DIR/cli/valet.php" which-php $SITE) $(which drush) "${@:3}"
+    elif [[ $2 == "uli" ]]; then
+        $(php "$DIR/cli/valet.php" which-php) $(which drush) uli --uri=$(php "$DIR/cli/valet.php" which-uri) "${@:3}"
+    else
+        $(php "$DIR/cli/valet.php" which-php)  $(which drush) "${@:2}"
+    fi
+
+    exit
+
 # Finally, for every other command we will just proxy into the PHP tool
 # and let it handle the request. These are commands which can be run
 # without sudo and don't require taking over terminals like Ngrok.


### PR DESCRIPTION
This will ensure that isolated sites use the correct version of php with Drush. 
User Login (ULI) has been improved with added uri which is known by Valet. 
This requires the added command which-uri to output the domain without any protocol.