### PR TITLE
Secure the proxies created for valet plus services

### DIFF
--- a/cli/ValetPlus/Elasticsearch.php
+++ b/cli/ValetPlus/Elasticsearch.php
@@ -246,7 +246,7 @@ class Elasticsearch extends AbstractDockerService
         }
 
         $this->restart($version);
-        $this->site->proxyCreate('elasticsearch', 'http://127.0.0.1:9200');
+        $this->site->proxyCreate('elasticsearch', 'http://127.0.0.1:9200', true);
     }
 
     /**

--- a/cli/ValetPlus/Mailhog.php
+++ b/cli/ValetPlus/Mailhog.php
@@ -72,7 +72,7 @@ class Mailhog extends AbstractService
     public function install(string $tld = 'test'): void
     {
         $this->brew->ensureInstalled(static::SERVICE_NAME);
-        $this->site->proxyCreate('mailhog', 'http://127.0.0.1:8025');
+        $this->site->proxyCreate('mailhog', 'http://127.0.0.1:8025', true);
         $this->setEnabled(static::STATE_ENABLED);
         $this->restart();
     }


### PR DESCRIPTION
This will create the proxy for elasticsearch and mailhog with secure certificates to ensure they work best.

I found that the way that chrome treats unsecure sites is that notifications are always disabled. 
Other issues could arise as well, like a redirect to the https which happened to me after trying to secure it with valet secure. 
